### PR TITLE
Support CycloneDX 1.2

### DIFF
--- a/lib/mix/tasks/sbom.cyclonedx.ex
+++ b/lib/mix/tasks/sbom.cyclonedx.ex
@@ -13,7 +13,7 @@ defmodule Mix.Tasks.Sbom.Cyclonedx do
 
     * `--output` (`-o`): the full path to the SBoM output file (default:
       #{@default_path})
-    * `--force` (`-f`): overwite existing files without prompting for
+    * `--force` (`-f`): overwrite existing files without prompting for
       confirmation
     * `--dev` (`-d`): include dependencies for non-production environments
       (including `dev`, `test` or `docs`); by default only dependencies for
@@ -21,37 +21,45 @@ defmodule Mix.Tasks.Sbom.Cyclonedx do
     * `--recurse` (`-r`): in an umbrella project, generate individual output
       files for each application, rather than a single file for the entire
       project
+    * `--schema` (`-s`): schema version to be used, defaults to "1.2".
 
   """
 
   @doc false
+  @impl Mix.Task
   def run(all_args) do
     {opts, _args} =
       OptionParser.parse!(
         all_args,
-        aliases: [o: :output, f: :force, d: :dev, r: :recurse],
-        strict: [output: :string, force: :boolean, dev: :boolean, recurse: :boolean]
+        aliases: [o: :output, f: :force, d: :dev, r: :recurse, s: :schema],
+        strict: [
+          output: :string,
+          force: :boolean,
+          dev: :boolean,
+          recurse: :boolean,
+          schema: :string
+        ]
       )
 
     output_path = opts[:output] || @default_path
-    environment = (!opts[:dev] && :prod) || nil
+    valiate_schema(opts)
 
-    # Mix.Task.run("deps.loadpaths", ["--no-compile", "--no-load-deps"])
+    environment = (!opts[:dev] && :prod) || nil
 
     apps = Mix.Project.apps_paths()
 
     if opts[:recurse] && apps do
       Enum.each(apps, &generate_bom(&1, output_path, environment, opts[:force]))
     else
-      generate_bom(output_path, environment, opts[:force])
+      generate_bom(output_path, environment, opts)
     end
   end
 
-  defp generate_bom(output_path, environment, force) do
+  defp generate_bom(output_path, environment, opts) do
     case SBoM.components_for_project(environment) do
       {:ok, components} ->
-        xml = SBoM.CycloneDX.bom(components)
-        create_file(output_path, xml, force: force)
+        xml = SBoM.CycloneDX.bom(components, opts)
+        create_file(output_path, xml, force: opts[:force])
 
       {:error, :unresolved_dependency} ->
         dependency_error()
@@ -68,5 +76,21 @@ defmodule Mix.Tasks.Sbom.Cyclonedx do
     shell = Mix.shell()
     shell.error("Unchecked dependencies; please run `mix deps.get`")
     Mix.raise("Can't continue due to errors on dependencies")
+  end
+
+  defp valiate_schema(opts) do
+    schema_versions = ["1.2", "1.1"]
+
+    if opts[:schema] && opts[:schema] not in schema_versions do
+      shell = Mix.shell()
+
+      shell.error(
+        "invalid cyclonedx schema version, available versions are #{
+          schema_versions |> Enum.join(", ")
+        }"
+      )
+
+      Mix.raise("Give correct cyclonedx schema version to continue.")
+    end
   end
 end

--- a/lib/sbom.ex
+++ b/lib/sbom.ex
@@ -82,7 +82,7 @@ defmodule SBoM do
   end
 
   defp component_from_dep(%{scm: Mix.SCM.Git, app: app}, opts) do
-    %{git: git, lock: lock, dest: dest} = opts
+    %{git: git, lock: lock, dest: _dest} = opts
 
     version =
       case opts[:tag] do

--- a/lib/sbom/cyclonedx.ex
+++ b/lib/sbom/cyclonedx.ex
@@ -33,7 +33,7 @@ defmodule SBoM.CycloneDX do
              {:metadata, [],
               [
                 {:timestamp, [], [[DateTime.utc_now() |> DateTime.to_iso8601()]]},
-                {:tools, [], [tool: [vendor: [["CycloneDX"]], name: [["Elixir module"]]]]}
+                {:tools, [], [tool: [name: [["SBoM Mix task for Elixir"]]]]}
               ]},
              {:components, [], Enum.map(components, &component/1)}
            ]}

--- a/test/mix/tasks/sbom.cyclonedx_test.exs
+++ b/test/mix/tasks/sbom.cyclonedx_test.exs
@@ -26,4 +26,15 @@ defmodule Mix.Tasks.Sbom.CyclonedxTest do
       assert_received {:mix_shell, :info, ["* creating bom.xml"]}
     end)
   end
+
+  test "schema validation" do
+    Mix.Project.in_project(__MODULE__, "test/fixtures/sample1", fn _mod ->
+      Mix.Task.rerun("sbom.cyclonedx", ["-d", "-f", "-s", "1.1"])
+      assert_received {:mix_shell, :info, ["* creating bom.xml"]}
+
+      assert_raise Mix.Error, "Give correct cyclonedx schema version to continue.", fn ->
+        Mix.Task.rerun("sbom.cyclonedx", ["-d", "-f", "-s", "invalid"])
+      end
+    end)
+  end
 end


### PR DESCRIPTION
Generate cyclonedx 1.2 by default.
Borrowed the convension [used in the npm package](https://www.npmjs.com/package/@cyclonedx/bom) for consistency 
## Changes
- add an option for specifying the schema version
```shell
mix sbom.cyclonedx  -s 1.4
```
- specifying invalid schema version throws an error
```shell
invalid cyclonedx schema version, available versions are 1.2, 1.1
** (Mix) Give correct cyclonedx schema version to continue.
```

closes #1 