### PR TITLE
Add :xmerl to list of extra applications

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -21,7 +21,7 @@ defmodule SBoM.MixProject do
   # Run "mix help compile.app" to learn about applications.
   def application do
     [
-      extra_applications: [:hex]
+      extra_applications: [:hex, :xmerl]
     ]
   end
 


### PR DESCRIPTION
There is a warning when including sbom as dependency with elixir 1.12

```
==> sbom
Compiling 5 files (.ex)
warning: :xmerl.export_simple/2 defined in application :xmerl is used by the current application but the current application does not depend on :xmerl. To fix this, you must do one of:
```