### PR TITLE
Fix missing dependency warning for xmerl

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -21,7 +21,7 @@ defmodule SBoM.MixProject do
   # Run "mix help compile.app" to learn about applications.
   def application do
     [
-      extra_applications: [:hex]
+      extra_applications: [:hex, :xmerl]
     ]
   end
 


### PR DESCRIPTION
This fixes the following warning:

```
warning: :xmerl.export_simple/2 defined in application :xmerl is used by the current application but the current application does not depend on :xmerl. To fix this, you must do one of:

  1. If :xmerl is part of Erlang/Elixir, you must include it under :extra_applications inside "def application" in your mix.exs

  2. If :xmerl is a dependency, make sure it is listed under "def deps" in your mix.exs

  3. In case you don't want to add a requirement to :xmerl, you may optionally skip this warning by adding [xref: [exclude: [:xmerl]]] to your "def project" in mix.exs

  lib/sbom/cyclonedx.ex:42: SBoM.CycloneDX.bom/2
```
