### PR TITLE
Update API for Elixir 1.16 compat 

### DIFF
--- a/lib/sbom.ex
+++ b/lib/sbom.ex
@@ -18,7 +18,7 @@ defmodule SBoM do
     Mix.Project.get!()
 
     {deps, not_ok} =
-      Mix.Dep.load_on_environment(env: environment)
+      Mix.Dep.Converger.converge(env: environment)
       |> Enum.split_with(&ok?/1)
 
     case not_ok do

--- a/mix.exs
+++ b/mix.exs
@@ -1,13 +1,13 @@
 defmodule SBoM.MixProject do
   use Mix.Project
 
-  @version "0.6.2"
+  @version "0.6.3"
 
   def project do
     [
       app: :sbom,
       version: @version,
-      elixir: "~> 1.7",
+      elixir: "~> 1.16",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       name: "SBoM",


### PR DESCRIPTION
This PR adds Elixir 1.16 compatibility.

Based on this commit:
https://github.com/elixir-lang/elixir/commit/d46fa4b0426525e5fa492e9a98dcbbb89034508f