### PR TITLE
Fix tests when running new converger

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -21,7 +21,7 @@ defmodule SBoM.MixProject do
   # Run "mix help compile.app" to learn about applications.
   def application do
     [
-      extra_applications: [:hex, :xmerl]
+      extra_applications: [:logger, :hex, :xmerl]
     ]
   end
 


### PR DESCRIPTION
The failure:
https://github.com/voltone/sbom/actions/runs/11028271392/job/30628155207
comes from the fact that the new converger performs logging and the `:logger` application was not started.