### PR TITLE
Implement Smoke Tests

### DIFF
--- a/.github/actions/validate-cyclonedx-bom/action.yml
+++ b/.github/actions/validate-cyclonedx-bom/action.yml
@@ -1,0 +1,66 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# SPDX-FileCopyrightText: 2025 Erlang Ecosystem Foundation
+
+name: "Validate CycloneDX BOM"
+description: "Validates a CycloneDX BOM file using cyclonedx-cli"
+inputs:
+  bom-file:
+    description: "Path to the BOM file to validate"
+    required: true
+  format:
+    description: "Format of the BOM file (json, xml, or protobuf)"
+    required: true
+  cyclone-version:
+    description: "CycloneDX schema version"
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: "Install CycloneDX CLI"
+      run: |
+        eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+        echo "PATH=$PATH" >> "$GITHUB_ENV"
+        brew tap cyclonedx/cyclonedx
+        brew install cyclonedx/cyclonedx/cyclonedx-cli
+      shell: bash
+
+    - name: "Convert protobuf to JSON (if needed)"
+      if: inputs.format == 'protobuf' && inputs.cyclone-version != '1.7'
+      env:
+        BOM_FILE: ${{ inputs.bom-file }}
+      run: |
+        cyclonedx convert \
+          --input-file "$BOM_FILE" \
+          --output-file "$BOM_FILE.json" \
+          --input-format protobuf \
+          --output-format json
+      shell: bash
+
+    - name: "Validate BOM"
+      env:
+        BOM_FILE: ${{ inputs.bom-file }}
+        FORMAT: ${{ inputs.format }}
+        CYCLONE_VERSION: ${{ inputs.cyclone-version }}
+      run: |
+        if [ "$CYCLONE_VERSION" == "1.7" ]; then
+          echo "⚠️ Skipping validation for CycloneDX 1.7 - CLI support not yet available"
+          echo "Enable validation once cyclonedx-cli supports schema version 1.7"
+          if [ "$FORMAT" == "protobuf" ]; then
+            echo "⚠️ Protobuf conversion also skipped for version 1.7"
+          fi
+        else
+          if [ "$FORMAT" == "protobuf" ]; then
+            cyclonedx validate --input-file "$BOM_FILE.json" --input-format json --fail-on-errors
+          else
+            cyclonedx validate --input-file "$BOM_FILE" --input-format "$FORMAT" --fail-on-errors
+          fi
+        fi
+      shell: bash
+
+    - name: "Cleanup temporary files"
+      if: inputs.format == 'protobuf' && inputs.cyclone-version != '1.7'
+      env:
+        BOM_FILE: ${{ inputs.bom-file }}
+      run: rm -f "$BOM_FILE.json"
+      shell: bash

--- a/.github/workflows/branch_main.yml
+++ b/.github/workflows/branch_main.yml
@@ -57,6 +57,18 @@ jobs:
     with:
       attest: false
 
+  smoke_test:
+    name: "Smoke Test"
+
+    needs: ['build']
+
+    permissions:
+      id-token: write
+      contents: read
+      attestations: write
+
+    uses: ./.github/workflows/part_smoke_test.yml
+
   dependency_submission:
     name: "Mix Dependency Submission"
 

--- a/.github/workflows/part_smoke_test.yml
+++ b/.github/workflows/part_smoke_test.yml
@@ -1,0 +1,159 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# SPDX-FileCopyrightText: 2025 Erlang Ecosystem Foundation
+
+on:
+  workflow_call: {}
+
+name: "Smoke Test"
+
+permissions:
+  contents: read
+
+jobs:
+  mix:
+    name: "Mix Task (${{ matrix.cyclone_version }}, ${{ matrix.format }})"
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        cyclone_version: ["1.3", "1.4", "1.5", "1.6", "1.7"]
+        format: ["json", "xml", "protobuf"]
+
+    env:
+      MIX_ENV: prod
+
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+        with:
+          submodules: true
+
+      - uses: ./.github/actions/setup-runtime-env
+        with:
+          mix-env: prod
+
+      - name: "Generate SBoM with Mix Task"
+        env:
+          CYCLONE_VERSION: ${{ matrix.cyclone_version }}
+          FORMAT: ${{ matrix.format }}
+          OUTPUT_FILE: bom_mix.${{ matrix.format == 'protobuf' && 'cdx' || matrix.format }}
+        run: |
+          mix sbom.cyclonedx \
+            --schema "$CYCLONE_VERSION" \
+            --format "$FORMAT" \
+            --output "$OUTPUT_FILE"
+
+      - name: "Validate SBoM"
+        uses: ./.github/actions/validate-cyclonedx-bom
+        with:
+          bom-file: bom_mix.${{ matrix.format == 'protobuf' && 'cdx' || matrix.format }}
+          format: ${{ matrix.format }}
+          cyclone-version: ${{ matrix.cyclone_version }}
+
+  burrito:
+    name: "Burrito Binary (${{ matrix.cyclone_version }}, ${{ matrix.format }})"
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        cyclone_version: ["1.3", "1.4", "1.5", "1.6", "1.7"]
+        format: ["json", "xml", "protobuf"]
+
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+        with:
+          submodules: true
+
+      - name: "Download Burrito Binary"
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v5.0.0
+        with:
+          name: binary
+          path: ./burrito_artifacts
+
+      - name: "Make Binary Executable"
+        run: |
+          chmod +x ./burrito_artifacts/mix_sbom_Linux_X64
+
+      - name: "Generate SBoM with Burrito Binary"
+        env:
+          CYCLONE_VERSION: ${{ matrix.cyclone_version }}
+          FORMAT: ${{ matrix.format }}
+          OUTPUT_FILE: bom_burrito.${{ matrix.format == 'protobuf' && 'cdx' || matrix.format }}
+        run: |
+          ./burrito_artifacts/mix_sbom_Linux_X64 \
+            --schema "$CYCLONE_VERSION" \
+            --format "$FORMAT" \
+            --output "$OUTPUT_FILE" \
+            .
+
+      - name: "Validate SBoM"
+        uses: ./.github/actions/validate-cyclonedx-bom
+        with:
+          bom-file: bom_burrito.${{ matrix.format == 'protobuf' && 'cdx' || matrix.format }}
+          format: ${{ matrix.format }}
+          cyclone-version: ${{ matrix.cyclone_version }}
+
+  escript:
+    name: "EScript (${{ matrix.cyclone_version }}, ${{ matrix.format }})"
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        cyclone_version: ["1.3", "1.4", "1.5", "1.6", "1.7"]
+        format: ["json", "xml", "protobuf"]
+
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+        with:
+          submodules: true
+
+      - uses: ./.github/actions/setup-runtime-env
+
+      - name: "Download EScript"
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v5.0.0
+        with:
+          name: escript
+          path: ./escript_artifacts
+
+      - name: "Make EScript Executable"
+        run: |
+          chmod +x ./escript_artifacts/mix_sbom_escript
+
+      - name: "Generate SBoM with EScript"
+        env:
+          CYCLONE_VERSION: ${{ matrix.cyclone_version }}
+          FORMAT: ${{ matrix.format }}
+          OUTPUT_FILE: bom_escript.${{ matrix.format == 'protobuf' && 'cdx' || matrix.format }}
+        run: |
+          ./escript_artifacts/mix_sbom_escript \
+            --schema "$CYCLONE_VERSION" \
+            --format "$FORMAT" \
+            --output "$OUTPUT_FILE" \
+            .
+
+      - name: "Validate SBoM"
+        uses: ./.github/actions/validate-cyclonedx-bom
+        with:
+          bom-file: bom_escript.${{ matrix.format == 'protobuf' && 'cdx' || matrix.format }}
+          format: ${{ matrix.format }}
+          cyclone-version: ${{ matrix.cyclone_version }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -69,6 +69,18 @@ jobs:
 
     uses: ./.github/workflows/part_dependency_submission.yml
 
+  smoke_test:
+    name: "Smoke Test"
+
+    needs: ['build']
+
+    permissions:
+      id-token: write
+      contents: read
+      attestations: write
+
+    uses: ./.github/workflows/part_smoke_test.yml
+
   dependency-review:
     name: "Dependency Review"
 

--- a/lib/sbom/cyclonedx/json/encodable.ex
+++ b/lib/sbom/cyclonedx/json/encodable.ex
@@ -126,6 +126,170 @@ end
 
 defimpl SBoM.CycloneDX.JSON.Encodable,
   for: [
+    SBoM.Cyclonedx.V17.Hash,
+    SBoM.Cyclonedx.V16.Hash,
+    SBoM.Cyclonedx.V15.Hash,
+    SBoM.Cyclonedx.V14.Hash,
+    SBoM.Cyclonedx.V13.Hash
+  ] do
+  alias SBoM.CycloneDX.JSON.Encoder
+
+  @type hash_alg() ::
+          SBoM.Cyclonedx.V13.HashAlg.t()
+          | SBoM.Cyclonedx.V14.HashAlg.t()
+          | SBoM.Cyclonedx.V15.HashAlg.t()
+          | SBoM.Cyclonedx.V16.HashAlg.t()
+          | SBoM.Cyclonedx.V17.HashAlg.t()
+
+  @impl SBoM.CycloneDX.JSON.Encodable
+  def to_encodable(hash) do
+    hash
+    |> Encoder.encodable()
+    |> Map.update("alg", nil, &hash_alg_to_string/1)
+    |> rename_value_to_content()
+  end
+
+  @spec rename_value_to_content(map()) :: map()
+  defp rename_value_to_content(map) do
+    case Map.pop(map, "value") do
+      {nil, map} -> map
+      {value, map} -> Map.put(map, "content", value)
+    end
+  end
+
+  @spec hash_alg_to_string(hash_alg()) :: String.t()
+  defp hash_alg_to_string(:HASH_ALG_NULL), do: ""
+  defp hash_alg_to_string(:HASH_ALG_MD_5), do: "MD5"
+  defp hash_alg_to_string(:HASH_ALG_SHA_1), do: "SHA-1"
+  defp hash_alg_to_string(:HASH_ALG_SHA_256), do: "SHA-256"
+  defp hash_alg_to_string(:HASH_ALG_SHA_384), do: "SHA-384"
+  defp hash_alg_to_string(:HASH_ALG_SHA_512), do: "SHA-512"
+  defp hash_alg_to_string(:HASH_ALG_SHA_3_256), do: "SHA3-256"
+  defp hash_alg_to_string(:HASH_ALG_SHA_3_384), do: "SHA3-384"
+  defp hash_alg_to_string(:HASH_ALG_SHA_3_512), do: "SHA3-512"
+  defp hash_alg_to_string(:HASH_ALG_BLAKE_2_B_256), do: "BLAKE2b-256"
+  defp hash_alg_to_string(:HASH_ALG_BLAKE_2_B_384), do: "BLAKE2b-384"
+  defp hash_alg_to_string(:HASH_ALG_BLAKE_2_B_512), do: "BLAKE2b-512"
+  defp hash_alg_to_string(:HASH_ALG_BLAKE_3), do: "BLAKE3"
+  defp hash_alg_to_string(:HASH_ALG_STREEBOG_256), do: "Streebog-256"
+  defp hash_alg_to_string(:HASH_ALG_STREEBOG_512), do: "Streebog-512"
+end
+
+defimpl SBoM.CycloneDX.JSON.Encodable,
+  for: [
+    SBoM.Cyclonedx.V17.ExternalReference,
+    SBoM.Cyclonedx.V16.ExternalReference,
+    SBoM.Cyclonedx.V15.ExternalReference,
+    SBoM.Cyclonedx.V14.ExternalReference,
+    SBoM.Cyclonedx.V13.ExternalReference
+  ] do
+  alias SBoM.CycloneDX.JSON.Encoder
+
+  @type external_reference_type() ::
+          SBoM.Cyclonedx.V13.ExternalReferenceType.t()
+          | SBoM.Cyclonedx.V14.ExternalReferenceType.t()
+          | SBoM.Cyclonedx.V15.ExternalReferenceType.t()
+          | SBoM.Cyclonedx.V16.ExternalReferenceType.t()
+          | SBoM.Cyclonedx.V17.ExternalReferenceType.t()
+
+  @impl SBoM.CycloneDX.JSON.Encodable
+  def to_encodable(external_reference) do
+    external_reference
+    |> Encoder.encodable()
+    |> Map.update("type", nil, &external_reference_type_to_string/1)
+  end
+
+  @spec external_reference_type_to_string(external_reference_type()) :: String.t()
+  defp external_reference_type_to_string(:EXTERNAL_REFERENCE_TYPE_OTHER), do: "other"
+  defp external_reference_type_to_string(:EXTERNAL_REFERENCE_TYPE_VCS), do: "vcs"
+
+  defp external_reference_type_to_string(:EXTERNAL_REFERENCE_TYPE_ISSUE_TRACKER), do: "issue-tracker"
+
+  defp external_reference_type_to_string(:EXTERNAL_REFERENCE_TYPE_WEBSITE), do: "website"
+  defp external_reference_type_to_string(:EXTERNAL_REFERENCE_TYPE_ADVISORIES), do: "advisories"
+  defp external_reference_type_to_string(:EXTERNAL_REFERENCE_TYPE_BOM), do: "bom"
+
+  defp external_reference_type_to_string(:EXTERNAL_REFERENCE_TYPE_MAILING_LIST), do: "mailing-list"
+
+  defp external_reference_type_to_string(:EXTERNAL_REFERENCE_TYPE_SOCIAL), do: "social"
+  defp external_reference_type_to_string(:EXTERNAL_REFERENCE_TYPE_CHAT), do: "chat"
+
+  defp external_reference_type_to_string(:EXTERNAL_REFERENCE_TYPE_DOCUMENTATION), do: "documentation"
+
+  defp external_reference_type_to_string(:EXTERNAL_REFERENCE_TYPE_SUPPORT), do: "support"
+
+  defp external_reference_type_to_string(:EXTERNAL_REFERENCE_TYPE_SOURCE_DISTRIBUTION), do: "source-distribution"
+
+  defp external_reference_type_to_string(:EXTERNAL_REFERENCE_TYPE_DISTRIBUTION), do: "distribution"
+
+  defp external_reference_type_to_string(:EXTERNAL_REFERENCE_TYPE_DISTRIBUTION_INTAKE), do: "distribution-intake"
+
+  defp external_reference_type_to_string(:EXTERNAL_REFERENCE_TYPE_LICENSE), do: "license"
+  defp external_reference_type_to_string(:EXTERNAL_REFERENCE_TYPE_BUILD_META), do: "build-meta"
+
+  defp external_reference_type_to_string(:EXTERNAL_REFERENCE_TYPE_BUILD_SYSTEM), do: "build-system"
+
+  defp external_reference_type_to_string(:EXTERNAL_REFERENCE_TYPE_RELEASE_NOTES), do: "release-notes"
+
+  defp external_reference_type_to_string(:EXTERNAL_REFERENCE_TYPE_SECURITY_CONTACT), do: "security-contact"
+
+  defp external_reference_type_to_string(:EXTERNAL_REFERENCE_TYPE_MODEL_CARD), do: "model-card"
+  defp external_reference_type_to_string(:EXTERNAL_REFERENCE_TYPE_LOG), do: "log"
+
+  defp external_reference_type_to_string(:EXTERNAL_REFERENCE_TYPE_CONFIGURATION), do: "configuration"
+
+  defp external_reference_type_to_string(:EXTERNAL_REFERENCE_TYPE_EVIDENCE), do: "evidence"
+  defp external_reference_type_to_string(:EXTERNAL_REFERENCE_TYPE_FORMULATION), do: "formulation"
+  defp external_reference_type_to_string(:EXTERNAL_REFERENCE_TYPE_ATTESTATION), do: "attestation"
+
+  defp external_reference_type_to_string(:EXTERNAL_REFERENCE_TYPE_THREAT_MODEL), do: "threat-model"
+
+  defp external_reference_type_to_string(:EXTERNAL_REFERENCE_TYPE_ADVERSARY_MODEL), do: "adversary-model"
+
+  defp external_reference_type_to_string(:EXTERNAL_REFERENCE_TYPE_RISK_ASSESSMENT), do: "risk-assessment"
+
+  defp external_reference_type_to_string(:EXTERNAL_REFERENCE_TYPE_VULNERABILITY_ASSERTION), do: "vulnerability-assertion"
+
+  defp external_reference_type_to_string(:EXTERNAL_REFERENCE_TYPE_EXPLOITABILITY_STATEMENT),
+    do: "exploitability-statement"
+
+  defp external_reference_type_to_string(:EXTERNAL_REFERENCE_TYPE_PENTEST_REPORT), do: "pentest-report"
+
+  defp external_reference_type_to_string(:EXTERNAL_REFERENCE_TYPE_STATIC_ANALYSIS_REPORT), do: "static-analysis-report"
+
+  defp external_reference_type_to_string(:EXTERNAL_REFERENCE_TYPE_DYNAMIC_ANALYSIS_REPORT), do: "dynamic-analysis-report"
+
+  defp external_reference_type_to_string(:EXTERNAL_REFERENCE_TYPE_RUNTIME_ANALYSIS_REPORT), do: "runtime-analysis-report"
+
+  defp external_reference_type_to_string(:EXTERNAL_REFERENCE_TYPE_COMPONENT_ANALYSIS_REPORT),
+    do: "component-analysis-report"
+
+  defp external_reference_type_to_string(:EXTERNAL_REFERENCE_TYPE_MATURITY_REPORT), do: "maturity-report"
+
+  defp external_reference_type_to_string(:EXTERNAL_REFERENCE_TYPE_CERTIFICATION_REPORT), do: "certification-report"
+
+  defp external_reference_type_to_string(:EXTERNAL_REFERENCE_TYPE_QUALITY_METRICS), do: "quality-metrics"
+
+  defp external_reference_type_to_string(:EXTERNAL_REFERENCE_TYPE_CODIFIED_INFRASTRUCTURE), do: "codified-infrastructure"
+
+  defp external_reference_type_to_string(:EXTERNAL_REFERENCE_TYPE_POAM), do: "poam"
+
+  defp external_reference_type_to_string(:EXTERNAL_REFERENCE_TYPE_ELECTRONIC_SIGNATURE), do: "electronic-signature"
+
+  defp external_reference_type_to_string(:EXTERNAL_REFERENCE_TYPE_DIGITAL_SIGNATURE), do: "digital-signature"
+
+  defp external_reference_type_to_string(:EXTERNAL_REFERENCE_TYPE_RFC_9116), do: "rfc-9116"
+  defp external_reference_type_to_string(:EXTERNAL_REFERENCE_TYPE_PATENT), do: "patent"
+
+  defp external_reference_type_to_string(:EXTERNAL_REFERENCE_TYPE_PATENT_FAMILY), do: "patent-family"
+
+  defp external_reference_type_to_string(:EXTERNAL_REFERENCE_TYPE_PATENT_ASSERTION), do: "patent-assertion"
+
+  defp external_reference_type_to_string(:EXTERNAL_REFERENCE_TYPE_CITATION), do: "citation"
+end
+
+defimpl SBoM.CycloneDX.JSON.Encodable,
+  for: [
     SBoM.Cyclonedx.V17.Dependency,
     SBoM.Cyclonedx.V16.Dependency,
     SBoM.Cyclonedx.V15.Dependency,

--- a/lib/sbom/cyclonedx/xml/derives.ex
+++ b/lib/sbom/cyclonedx/xml/derives.ex
@@ -306,7 +306,7 @@ Protocol.derive(Encodable, SBoM.Cyclonedx.V13.OrganizationalEntity,
 )
 
 Protocol.derive(Encodable, SBoM.Cyclonedx.V17.LicenseChoice,
-  element_name: :licenses,
+  element_name: :license,
   attributes: [
     {:"bom-ref", :bom_ref}
   ],
@@ -431,7 +431,6 @@ Protocol.derive(Encodable, SBoM.Cyclonedx.V13.License,
   ]
 )
 
-# Dependency derives
 Protocol.derive(Encodable, SBoM.Cyclonedx.V17.Dependency,
   element_name: :dependency,
   attributes: [

--- a/lib/sbom/cyclonedx/xml/encodable.ex
+++ b/lib/sbom/cyclonedx/xml/encodable.ex
@@ -47,6 +47,173 @@ end
 
 defimpl SBoM.CycloneDX.XML.Encodable,
   for: [
+    SBoM.Cyclonedx.V17.ExternalReference,
+    SBoM.Cyclonedx.V16.ExternalReference,
+    SBoM.Cyclonedx.V15.ExternalReference,
+    SBoM.Cyclonedx.V14.ExternalReference,
+    SBoM.Cyclonedx.V13.ExternalReference
+  ] do
+  alias SBoM.CycloneDX.XML.Helpers
+
+  @type external_reference_type() ::
+          SBoM.Cyclonedx.V13.ExternalReferenceType.t()
+          | SBoM.Cyclonedx.V14.ExternalReferenceType.t()
+          | SBoM.Cyclonedx.V15.ExternalReferenceType.t()
+          | SBoM.Cyclonedx.V16.ExternalReferenceType.t()
+          | SBoM.Cyclonedx.V17.ExternalReferenceType.t()
+
+  @impl SBoM.CycloneDX.XML.Encodable
+  def to_xml_element(external_reference) do
+    external_reference =
+      Map.update!(external_reference, :type, &external_reference_type_to_string/1)
+
+    # Use helpers to build structure
+    attrs = Helpers.encode_fields_as_attrs([{:type, :type}], external_reference)
+
+    content =
+      Helpers.encode_fields_as_elements(
+        [
+          {:url, :url, :wrap},
+          {:comment, :comment, :wrap},
+          {:hashes, :hashes, :wrap},
+          {:properties, :properties, :unwrap}
+        ],
+        external_reference
+      )
+
+    {:reference, attrs, content}
+  end
+
+  @spec external_reference_type_to_string(external_reference_type()) :: String.t()
+  defp external_reference_type_to_string(:EXTERNAL_REFERENCE_TYPE_OTHER), do: "other"
+  defp external_reference_type_to_string(:EXTERNAL_REFERENCE_TYPE_VCS), do: "vcs"
+
+  defp external_reference_type_to_string(:EXTERNAL_REFERENCE_TYPE_ISSUE_TRACKER), do: "issue-tracker"
+
+  defp external_reference_type_to_string(:EXTERNAL_REFERENCE_TYPE_WEBSITE), do: "website"
+  defp external_reference_type_to_string(:EXTERNAL_REFERENCE_TYPE_ADVISORIES), do: "advisories"
+  defp external_reference_type_to_string(:EXTERNAL_REFERENCE_TYPE_BOM), do: "bom"
+
+  defp external_reference_type_to_string(:EXTERNAL_REFERENCE_TYPE_MAILING_LIST), do: "mailing-list"
+
+  defp external_reference_type_to_string(:EXTERNAL_REFERENCE_TYPE_SOCIAL), do: "social"
+  defp external_reference_type_to_string(:EXTERNAL_REFERENCE_TYPE_CHAT), do: "chat"
+
+  defp external_reference_type_to_string(:EXTERNAL_REFERENCE_TYPE_DOCUMENTATION), do: "documentation"
+
+  defp external_reference_type_to_string(:EXTERNAL_REFERENCE_TYPE_SUPPORT), do: "support"
+
+  defp external_reference_type_to_string(:EXTERNAL_REFERENCE_TYPE_SOURCE_DISTRIBUTION), do: "source-distribution"
+
+  defp external_reference_type_to_string(:EXTERNAL_REFERENCE_TYPE_DISTRIBUTION), do: "distribution"
+
+  defp external_reference_type_to_string(:EXTERNAL_REFERENCE_TYPE_DISTRIBUTION_INTAKE), do: "distribution-intake"
+
+  defp external_reference_type_to_string(:EXTERNAL_REFERENCE_TYPE_LICENSE), do: "license"
+  defp external_reference_type_to_string(:EXTERNAL_REFERENCE_TYPE_BUILD_META), do: "build-meta"
+
+  defp external_reference_type_to_string(:EXTERNAL_REFERENCE_TYPE_BUILD_SYSTEM), do: "build-system"
+
+  defp external_reference_type_to_string(:EXTERNAL_REFERENCE_TYPE_RELEASE_NOTES), do: "release-notes"
+
+  defp external_reference_type_to_string(:EXTERNAL_REFERENCE_TYPE_SECURITY_CONTACT), do: "security-contact"
+
+  defp external_reference_type_to_string(:EXTERNAL_REFERENCE_TYPE_MODEL_CARD), do: "model-card"
+  defp external_reference_type_to_string(:EXTERNAL_REFERENCE_TYPE_LOG), do: "log"
+
+  defp external_reference_type_to_string(:EXTERNAL_REFERENCE_TYPE_CONFIGURATION), do: "configuration"
+
+  defp external_reference_type_to_string(:EXTERNAL_REFERENCE_TYPE_EVIDENCE), do: "evidence"
+  defp external_reference_type_to_string(:EXTERNAL_REFERENCE_TYPE_FORMULATION), do: "formulation"
+  defp external_reference_type_to_string(:EXTERNAL_REFERENCE_TYPE_ATTESTATION), do: "attestation"
+
+  defp external_reference_type_to_string(:EXTERNAL_REFERENCE_TYPE_THREAT_MODEL), do: "threat-model"
+
+  defp external_reference_type_to_string(:EXTERNAL_REFERENCE_TYPE_ADVERSARY_MODEL), do: "adversary-model"
+
+  defp external_reference_type_to_string(:EXTERNAL_REFERENCE_TYPE_RISK_ASSESSMENT), do: "risk-assessment"
+
+  defp external_reference_type_to_string(:EXTERNAL_REFERENCE_TYPE_VULNERABILITY_ASSERTION), do: "vulnerability-assertion"
+
+  defp external_reference_type_to_string(:EXTERNAL_REFERENCE_TYPE_EXPLOITABILITY_STATEMENT),
+    do: "exploitability-statement"
+
+  defp external_reference_type_to_string(:EXTERNAL_REFERENCE_TYPE_PENTEST_REPORT), do: "pentest-report"
+
+  defp external_reference_type_to_string(:EXTERNAL_REFERENCE_TYPE_STATIC_ANALYSIS_REPORT), do: "static-analysis-report"
+
+  defp external_reference_type_to_string(:EXTERNAL_REFERENCE_TYPE_DYNAMIC_ANALYSIS_REPORT), do: "dynamic-analysis-report"
+
+  defp external_reference_type_to_string(:EXTERNAL_REFERENCE_TYPE_RUNTIME_ANALYSIS_REPORT), do: "runtime-analysis-report"
+
+  defp external_reference_type_to_string(:EXTERNAL_REFERENCE_TYPE_COMPONENT_ANALYSIS_REPORT),
+    do: "component-analysis-report"
+
+  defp external_reference_type_to_string(:EXTERNAL_REFERENCE_TYPE_MATURITY_REPORT), do: "maturity-report"
+
+  defp external_reference_type_to_string(:EXTERNAL_REFERENCE_TYPE_CERTIFICATION_REPORT), do: "certification-report"
+
+  defp external_reference_type_to_string(:EXTERNAL_REFERENCE_TYPE_QUALITY_METRICS), do: "quality-metrics"
+
+  defp external_reference_type_to_string(:EXTERNAL_REFERENCE_TYPE_CODIFIED_INFRASTRUCTURE), do: "codified-infrastructure"
+
+  defp external_reference_type_to_string(:EXTERNAL_REFERENCE_TYPE_POAM), do: "poam"
+
+  defp external_reference_type_to_string(:EXTERNAL_REFERENCE_TYPE_ELECTRONIC_SIGNATURE), do: "electronic-signature"
+
+  defp external_reference_type_to_string(:EXTERNAL_REFERENCE_TYPE_DIGITAL_SIGNATURE), do: "digital-signature"
+
+  defp external_reference_type_to_string(:EXTERNAL_REFERENCE_TYPE_RFC_9116), do: "rfc-9116"
+  defp external_reference_type_to_string(:EXTERNAL_REFERENCE_TYPE_PATENT), do: "patent"
+
+  defp external_reference_type_to_string(:EXTERNAL_REFERENCE_TYPE_PATENT_FAMILY), do: "patent-family"
+
+  defp external_reference_type_to_string(:EXTERNAL_REFERENCE_TYPE_PATENT_ASSERTION), do: "patent-assertion"
+
+  defp external_reference_type_to_string(:EXTERNAL_REFERENCE_TYPE_CITATION), do: "citation"
+end
+
+defimpl SBoM.CycloneDX.XML.Encodable,
+  for: [
+    SBoM.Cyclonedx.V17.Hash,
+    SBoM.Cyclonedx.V16.Hash,
+    SBoM.Cyclonedx.V15.Hash,
+    SBoM.Cyclonedx.V14.Hash,
+    SBoM.Cyclonedx.V13.Hash
+  ] do
+  @type hash_alg() ::
+          SBoM.Cyclonedx.V13.HashAlg.t()
+          | SBoM.Cyclonedx.V14.HashAlg.t()
+          | SBoM.Cyclonedx.V15.HashAlg.t()
+          | SBoM.Cyclonedx.V16.HashAlg.t()
+          | SBoM.Cyclonedx.V17.HashAlg.t()
+
+  @impl SBoM.CycloneDX.XML.Encodable
+  def to_xml_element(hash) do
+    alg_string = hash_alg_to_string(hash.alg)
+    {:hash, [{:alg, alg_string}], [[hash.value]]}
+  end
+
+  @spec hash_alg_to_string(hash_alg()) :: String.t()
+  defp hash_alg_to_string(:HASH_ALG_NULL), do: ""
+  defp hash_alg_to_string(:HASH_ALG_MD_5), do: "MD5"
+  defp hash_alg_to_string(:HASH_ALG_SHA_1), do: "SHA-1"
+  defp hash_alg_to_string(:HASH_ALG_SHA_256), do: "SHA-256"
+  defp hash_alg_to_string(:HASH_ALG_SHA_384), do: "SHA-384"
+  defp hash_alg_to_string(:HASH_ALG_SHA_512), do: "SHA-512"
+  defp hash_alg_to_string(:HASH_ALG_SHA_3_256), do: "SHA3-256"
+  defp hash_alg_to_string(:HASH_ALG_SHA_3_384), do: "SHA3-384"
+  defp hash_alg_to_string(:HASH_ALG_SHA_3_512), do: "SHA3-512"
+  defp hash_alg_to_string(:HASH_ALG_BLAKE_2_B_256), do: "BLAKE2b-256"
+  defp hash_alg_to_string(:HASH_ALG_BLAKE_2_B_384), do: "BLAKE2b-384"
+  defp hash_alg_to_string(:HASH_ALG_BLAKE_2_B_512), do: "BLAKE2b-512"
+  defp hash_alg_to_string(:HASH_ALG_BLAKE_3), do: "BLAKE3"
+  defp hash_alg_to_string(:HASH_ALG_STREEBOG_256), do: "Streebog-256"
+  defp hash_alg_to_string(:HASH_ALG_STREEBOG_512), do: "Streebog-512"
+end
+
+defimpl SBoM.CycloneDX.XML.Encodable,
+  for: [
     SBoM.Cyclonedx.V17.Component,
     SBoM.Cyclonedx.V16.Component,
     SBoM.Cyclonedx.V15.Component,
@@ -93,12 +260,12 @@ defimpl SBoM.CycloneDX.XML.Encodable,
           {:description, :description, :wrap},
           {:scope, :scope, :wrap},
           {:hashes, :hashes, :unwrap},
-          {:licenses, :licenses, :keep},
+          {:licenses, :licenses, :unwrap},
           {:copyright, :copyright, :wrap},
           {:patentAssertions, :patent_assertions, :unwrap},
           {:cpe, :cpe, :wrap},
           {:purl, :purl, :wrap},
-          {:externalReferences, :external_references, :unwrap},
+          {:externalReferences, :external_references, :wrap},
           {:properties, :properties, :unwrap},
           {:evidence, :evidence, :unwrap},
           {:releaseNotes, :release_notes, :unwrap},

--- a/lib/sbom/cyclonedx/xml/helpers.ex
+++ b/lib/sbom/cyclonedx/xml/helpers.ex
@@ -64,7 +64,15 @@ defmodule SBoM.CycloneDX.XML.Helpers do
   end
 
   defp apply_action(xml_name, value, :unwrap) do
-    {_elem, attrs, content} = Encodable.to_xml_element(value)
+    {attrs, content} =
+      case Encodable.to_xml_element(value) do
+        list when is_list(list) ->
+          {[], Enum.flat_map(list, fn {_elem, _attrs, content} -> content end)}
+
+        {_elem, attrs, content} ->
+          {attrs, content}
+      end
+
     {xml_name, attrs, content}
   end
 


### PR DESCRIPTION
Implement smoke tests that run the tool via Mix task, escript, and standalone binary to generate SBOMs for each supported version and format. Validate all generated BOMs with `cyclonedx validate` to ensure correctness.
