### PR TITLE
Allow Escript Usage in Action

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,8 @@ an SBoM for your project.
   (defaults to repository root)
 - `schema`: CycloneDX schema version (defaults to "1.6")
 - `format`: Output format, either "json" or "xml" (defaults to "json")
+- `reuse-beam`: Use local BEAM installation instead of pre-compiled binaries
+  (defaults to "false")
 
 ### Outputs
 
@@ -137,6 +139,33 @@ an SBoM for your project.
 The action automatically handles downloading the correct binary for your 
 runner's architecture and verifies its provenance using GitHub's attestation
 system.
+
+### Using Local BEAM (Recommended)
+
+For the most accurate dependency analysis, it's recommended to use the local 
+BEAM installation by setting `reuse-beam: true`. This approach:
+
+- Properly detects Elixir and Erlang versions in the generated SBoM
+- Works with your project's specific runtime environment
+- Provides more accurate dependency information
+
+To use this approach, first set up Elixir/Erlang in your workflow:
+
+```yaml
+- name: Set up Elixir
+  uses: erlef/setup-beam@v1
+  with:
+    elixir-version: '1.17.3'
+    otp-version: '27.1'
+
+- name: Get dependencies
+  run: mix deps.get
+
+- name: Generate SBoM
+  uses: erlef/mix_sbom@v0
+  with:
+    reuse-beam: true
+```
 
 **Note**: For most detailed dependency analysis, you should run `mix deps.get`
 before using this action to ensure all dependencies are resolved.

--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,10 @@ inputs:
     required: true
     description: "CycloneDX Output Format"
     default: "json"
+  reuse-beam:
+    required: false
+    description: "Use local BEAM installation instead of pre-compiled binaries. Requires Elixir/Erlang to be set up beforehand."
+    default: "false"
 outputs:
   sbom-path:
     description: "Path to the generated SBoM"
@@ -28,18 +32,19 @@ runs:
   using: "composite"
   steps:
     - name: "Download SBoM Tool"
-      run: >-
-        gh release download
-        "$TAG"
-        --repo erlef/mix_sbom
-        --pattern "mix_sbom_${{ runner.os }}_${{ runner.arch }}"
-        --output mix_sbom
+      run: |
+        if [ "$REUSE_BEAM" = "true" ]; then
+          gh release download "$TAG" --repo erlef/mix_sbom --pattern "mix_sbom.escript" --output mix_sbom
+        else
+          gh release download "$TAG" --repo erlef/mix_sbom --pattern "mix_sbom_${{ runner.os }}_${{ runner.arch }}" --output mix_sbom
+        fi
       shell: "bash"
       working-directory: "${{ runner.temp }}"
       env:
         # TODO: Put real version
         TAG: "VERSION"
         GITHUB_TOKEN: ${{ github.token }}
+        REUSE_BEAM: "${{ inputs.reuse-beam }}"
     - name: "Verify SBoM Tool Provenance"
       run: >-
         gh attestation verify
@@ -69,7 +74,7 @@ runs:
       run: >-
         "${{ runner.temp }}/mix_sbom"
         --schema="$SCHEMA"
-        --version="$VERSION"
+        --format="$FORMAT"
         --output="$OUTPUT_PATH"
         "$PROJECT_PATH"
       shell: "bash"
@@ -77,4 +82,4 @@ runs:
         PROJECT_PATH: "${{ inputs.project-path }}"
         SCHEMA: "${{ inputs.schema }}"
         FORMAT: "${{ inputs.format }}"
-        "OUTPUT_PATH": "${{ steps.define_output.outputs.output }}"
+        OUTPUT_PATH: "${{ steps.define_output.outputs.output }}"


### PR DESCRIPTION
Set up escript usage in the provided GitHub Action so users can run the tool with their existing BEAM environment instead of relying on the Burrito standalone binary.
