### PR TITLE
CI Hex Publish

### DIFF
--- a/.github/workflows/part_publish.yml
+++ b/.github/workflows/part_publish.yml
@@ -1,0 +1,38 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# SPDX-FileCopyrightText: 2025 Erlang Ecosystem Foundation
+
+on:
+  workflow_call:
+    inputs:
+      releaseName:
+        required: false
+        type: string
+    secrets:
+      HEX_API_KEY:
+        required: false
+
+name: "Publish"
+
+permissions:
+  contents: read
+
+jobs:
+  hex_publish:
+    name: mix hex.publish
+
+    runs-on: ubuntu-latest
+
+    environment: "release"
+
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+      - uses: ./.github/actions/setup-runtime-env
+
+      - run: mix hex.publish --yes
+        env:
+          HEX_API_KEY: ${{ secrets.HEX_API_KEY }}

--- a/.github/workflows/tag-stable.yml
+++ b/.github/workflows/tag-stable.yml
@@ -54,3 +54,12 @@ jobs:
     with:
       releaseName: "${{ github.ref_name }}"
       stable: true
+
+  publish:
+    name: "Publish"
+
+    uses: ./.github/workflows/part_publish.yml
+    with:
+      releaseName: "${{ github.ref_name }}"
+    secrets:
+      HEX_API_KEY: "${{ secrets.HEX_API_KEY }}"

--- a/.github/workflows/tag-unstable.yml
+++ b/.github/workflows/tag-unstable.yml
@@ -54,3 +54,12 @@ jobs:
     with:
       releaseName: "${{ github.ref_name }}"
       stable: false
+
+  publish:
+    name: "Publish"
+
+    uses: ./.github/workflows/part_publish.yml
+    with:
+      releaseName: "${{ github.ref_name }}"
+    secrets:
+      HEX_API_KEY: "${{ secrets.HEX_API_KEY }}"


### PR DESCRIPTION
Implement Hex publishing through tag-based CI actions to automate releases when a version tag is pushed.
