### PR TITLE
Expose Full OTP Purl

### DIFF
--- a/lib/sbom/cyclonedx.ex
+++ b/lib/sbom/cyclonedx.ex
@@ -79,7 +79,7 @@ defmodule SBoM.CycloneDX do
     bom_struct(:Bom, version,
       spec_version: version,
       serial_number: urn_uuid(),
-      version: 1,
+      version: 0,
       metadata: bom_struct(:Metadata, version)
     )
   end

--- a/lib/sbom/scm/system.ex
+++ b/lib/sbom/scm/system.ex
@@ -91,36 +91,68 @@ defmodule SBoM.SCM.SBoM.SCM.System do
   @impl SBoM.SCM
   def mix_dep_to_purl(app, version)
 
-  def mix_dep_to_purl({app, _version_requirement, _opts}, _version) when is_elixir_app(app) do
+  def mix_dep_to_purl({app, _version_requirement, _opts}, version) when is_elixir_app(app) do
+    git_ref =
+      case version do
+        nil -> "heads/main"
+        v -> "tags/v#{v}"
+      end
+
     Purl.new!(%Purl{
       type: "otp",
       name: to_string(app),
       subpath: ["lib", to_string(app)],
-      qualifiers: %{"vcs_url" => "git+https://github.com/elixir-lang/elixir.git"}
+      version: version,
+      qualifiers: %{
+        "repository_url" => "https://github.com/elixir-lang/elixir",
+        "download_url" => "https://github.com/elixir-lang/elixir/archive/refs/#{git_ref}.zip",
+        "vcs_url" => "git+https://github.com/elixir-lang/elixir.git"
+      }
     })
   end
 
-  def mix_dep_to_purl({app, _version_requirement, _opts}, _version) when is_erlang_app(app) do
+  def mix_dep_to_purl({app, _version_requirement, _opts}, version) when is_erlang_app(app) do
+    git_ref =
+      case version do
+        nil -> "heads/master"
+        v -> "tags/OTP-#{v}"
+      end
+
     Purl.new!(%Purl{
       type: "otp",
       name: to_string(app),
       subpath: ["lib", to_string(app)],
-      qualifiers: %{"vcs_url" => "git+https://github.com/erlang/otp.git"}
+      qualifiers: %{
+        "repository_url" => "https://github.com/erlang/otp",
+        "download_url" => "https://github.com/erlang/otp/archive/refs/#{git_ref}.zip",
+        "vcs_url" => "git+https://github.com/erlang/otp.git"
+      }
     })
   end
 
-  def mix_dep_to_purl({app, _version_requirement, _opts}, _version) when is_hex_app(app) do
+  def mix_dep_to_purl({app, _version_requirement, _opts}, version) when is_hex_app(app) do
+    git_ref =
+      case version do
+        nil -> "heads/main"
+        v -> "tags/v#{v}"
+      end
+
     Purl.new!(%Purl{
       type: "otp",
       name: to_string(app),
-      qualifiers: %{"vcs_url" => "git+https://github.com/hexpm/hex.git"}
+      qualifiers: %{
+        "repository_url" => "https://github.com/hexpm/hex",
+        "download_url" => "https://github.com/hexpm/hex/archive/refs/#{git_ref}.zip",
+        "vcs_url" => "git+https://github.com/hexpm/hex.git"
+      }
     })
   end
 
-  def mix_dep_to_purl({app, _version_requirement, _opts}, _version) do
+  def mix_dep_to_purl({app, _version_requirement, _opts}, version) do
     Purl.new!(%Purl{
       type: "otp",
-      name: to_string(app)
+      name: to_string(app),
+      version: version
     })
   end
 end

--- a/test/sbom/scm/hex/scm_test.exs
+++ b/test/sbom/scm/hex/scm_test.exs
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# SPDX-FileCopyrightText: 2025 Erlang Ecosystem Foundation
+
+defmodule SBoM.SCM.Hex.SCMTest do
+  use SBoM.FixtureCase, async: false
+
+  alias SBoM.SCM.Hex.SCM
+
+  doctest SCM
+end

--- a/test/sbom/scm/mix/scm/git_test.exs
+++ b/test/sbom/scm/mix/scm/git_test.exs
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# SPDX-FileCopyrightText: 2025 Erlang Ecosystem Foundation
+
+defmodule SBoM.SCM.Mix.SCM.GitTest do
+  use SBoM.FixtureCase, async: false
+
+  alias SBoM.SCM.Mix.SCM.Git
+
+  doctest Git
+end

--- a/test/sbom/scm/mix/scm/path_test.exs
+++ b/test/sbom/scm/mix/scm/path_test.exs
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# SPDX-FileCopyrightText: 2025 Erlang Ecosystem Foundation
+
+defmodule SBoM.SCM.Mix.SCM.PathTest do
+  use SBoM.FixtureCase, async: false
+
+  alias SBoM.SCM.Mix.SCM.Path
+
+  doctest Path
+end

--- a/test/sbom/scm/system_test.exs
+++ b/test/sbom/scm/system_test.exs
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# SPDX-FileCopyrightText: 2025 Erlang Ecosystem Foundation
+
+defmodule SBoM.SCM.Hex.SystemTest do
+  use SBoM.FixtureCase, async: false
+
+  alias SBoM.SCM.System
+
+  doctest System
+end

--- a/test/sbom/scm_test.exs
+++ b/test/sbom/scm_test.exs
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# SPDX-FileCopyrightText: 2025 Erlang Ecosystem Foundation
+
+defmodule SBoM.SCMTest do
+  use SBoM.FixtureCase, async: false
+
+  alias SBoM.SCM
+
+  doctest SCM
+end


### PR DESCRIPTION
Expose the full OTP PURL by adding the missing `vcs_url`, `download_url`, and `repository_url` qualifiers, bringing it in line with the standard’s requirements.


See https://github.com/package-url/purl-spec/pull/472