### PR TITLE
Implement all CLI Args

### DIFF
--- a/.github/workflows/part_test.yml
+++ b/.github/workflows/part_test.yml
@@ -154,7 +154,7 @@ jobs:
           mix coveralls.github \
             --exclude test \
             --include property \
-            --timeout 120000
+            --timeout 600000
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/lib/sbom/fetcher/mix_file.ex
+++ b/lib/sbom/fetcher/mix_file.ex
@@ -135,8 +135,16 @@ defmodule SBoM.Fetcher.MixFile do
        mix_dep: {app, requirement, opts},
        optional: Keyword.get(opts, :optional, false),
        runtime: Keyword.get(opts, :runtime, app?),
-       targets: Keyword.get(opts, :targets, :*),
-       only: Keyword.get(opts, :only, :*),
+       targets:
+         case Keyword.fetch(opts, :targets) do
+           {:ok, targets} -> List.wrap(targets)
+           :error -> :*
+         end,
+       only:
+         case Keyword.fetch(opts, :only) do
+           {:ok, only} -> List.wrap(only)
+           :error -> :*
+         end,
        version_requirement: requirement
      }}
   end

--- a/test/fixtures/filterable/mix.exs
+++ b/test/fixtures/filterable/mix.exs
@@ -1,0 +1,61 @@
+defmodule Filterable.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :filterable,
+      version: "0.1.0",
+      elixir: "~> 1.8",
+      start_permanent: Mix.env() == :prod,
+      deps: deps()
+    ]
+  end
+
+  # Run "mix help compile.app" to learn about applications.
+  def application do
+    [
+      extra_applications: [:logger]
+    ]
+  end
+
+  # Run "mix help deps" to learn about dependencies.
+  defp deps do
+    [
+      # No only/targets specified - should be included in all cases (default [:*])
+      {:jason, "~> 1.1"},
+
+      # Only development dependencies
+      {:ex_doc, "~> 0.21.2", only: :dev},
+      {:dialyxir, "~> 1.0", only: :dev},
+
+      # Only test dependencies
+      {:meck, "~> 0.8.13", only: :test},
+      {:excoveralls, "~> 0.10", only: :test},
+
+      # Only production dependencies
+      {:hackney, "~> 1.15", only: :prod},
+
+      # Multiple environments
+      {:sweet_xml, "~> 0.6.6", only: [:dev, :test]},
+      {:telemetry, "~> 0.4", only: [:prod, :dev]},
+
+      # With targets (mix specific option)
+      {:phoenix, "~> 1.5", targets: [:host]},
+      {:nerves, "~> 1.6", targets: [:rpi]},
+
+      # With both only and targets
+      {:phoenix_live_dashboard, "~> 0.4", only: :dev, targets: [:host]},
+      {:circuits_gpio, "~> 0.4", only: [:dev, :test], targets: [:rpi]},
+
+      # Optional dependencies
+      {:optional_dep, "~> 1.0", optional: true},
+      {:optional_dev_dep, "~> 2.0", optional: true, only: :dev},
+
+      # Runtime false (build-time only)
+      {:mix_test_watch, "~> 1.0", only: :dev, runtime: false},
+
+      # Complex combinations
+      {:complex_dep, "~> 1.0", only: [:dev, :test], targets: [:host, :rpi], optional: true}
+    ]
+  end
+end

--- a/test/mix/tasks/sbom.cyclonedx_test.exs
+++ b/test/mix/tasks/sbom.cyclonedx_test.exs
@@ -35,7 +35,7 @@ defmodule Mix.Tasks.Sbom.CyclonedxTest do
           Mix.Task.rerun("deps.get")
           Mix.Shell.Process.flush()
 
-          Mix.Task.rerun("sbom.cyclonedx", ["-d", "-f", "-o", bom_path])
+          Mix.Task.rerun("sbom.cyclonedx", ["-f", "-o", bom_path])
           assert_received {:mix_shell, :info, ["* creating bom.cdx"]}
 
           assert_valid_cyclonedx_bom(bom_path, :protobuf)
@@ -48,7 +48,7 @@ defmodule Mix.Tasks.Sbom.CyclonedxTest do
   @tag fixture_app: "sample1"
   test "schema validation", %{app_path: app_path} do
     Util.in_project(app_path, fn _mix_module ->
-      Mix.Task.rerun("sbom.cyclonedx", ["-d", "-f", "-s", "1.3"])
+      Mix.Task.rerun("sbom.cyclonedx", ["-f", "-s", "1.3"])
       assert_received {:mix_shell, :info, ["* creating bom.cdx.json"]}
 
       msg = Regex.escape("invalid value \"invalid\" for --schema(-s) option")
@@ -67,7 +67,7 @@ defmodule Mix.Tasks.Sbom.CyclonedxTest do
         Util.in_project(app_path, fn _mix_module ->
           bom_path = Path.join(app_path, "bom.cdx.json")
 
-          Mix.Task.rerun("sbom.cyclonedx", ["-d", "-f", "-o", bom_path])
+          Mix.Task.rerun("sbom.cyclonedx", ["-f", "-o", bom_path])
           assert_received {:mix_shell, :info, ["* creating bom.cdx.json"]}
 
           assert_valid_cyclonedx_bom(bom_path, :json)
@@ -84,7 +84,7 @@ defmodule Mix.Tasks.Sbom.CyclonedxTest do
         Util.in_project(app_path, fn _mix_module ->
           bom_path = Path.join([app_path, "apps", "child_app_name_to_replace", "bom.cdx.json"])
 
-          Mix.Task.rerun("sbom.cyclonedx", ["-d", "-f", "-r"])
+          Mix.Task.rerun("sbom.cyclonedx", ["-f", "-r"])
           assert_received {:mix_shell, :info, ["==> child_app_name_to_replace"]}
           assert_received {:mix_shell, :info, ["* creating bom.cdx.json"]}
 
@@ -92,5 +92,143 @@ defmodule Mix.Tasks.Sbom.CyclonedxTest do
         end)
       end)
     end)
+  end
+
+  describe "filtering with only and targets options" do
+    @tag :tmp_dir
+    @tag fixture_app: "filterable"
+    test "filters dependencies by only option", %{app_path: app_path} do
+      Util.in_project(app_path, fn _mix_module ->
+        # Test filtering for dev only
+        dev_bom_path = Path.join(app_path, "bom_dev.cdx.json")
+        Mix.Task.rerun("sbom.cyclonedx", ["-f", "-o", dev_bom_path, "--only", "dev"])
+        assert_received {:mix_shell, :info, ["* creating bom_dev.cdx.json"]}
+
+        dev_bom_content = File.read!(dev_bom_path)
+
+        # Should include dev dependencies
+        assert String.contains?(dev_bom_content, "ex_doc")
+        assert String.contains?(dev_bom_content, "dialyxir")
+        assert String.contains?(dev_bom_content, "phoenix_live_dashboard")
+
+        # Should include dependencies available in all envs
+        assert String.contains?(dev_bom_content, "jason")
+
+        # Should include multi-env deps that include dev
+        assert String.contains?(dev_bom_content, "sweet_xml")
+        assert String.contains?(dev_bom_content, "telemetry")
+
+        # Should NOT include test-only dependencies
+        refute String.contains?(dev_bom_content, "meck")
+        refute String.contains?(dev_bom_content, "excoveralls")
+
+        # Should NOT include prod-only dependencies
+        refute String.contains?(dev_bom_content, "hackney")
+
+        # Test filtering for test only
+        test_bom_path = Path.join(app_path, "bom_test.cdx.json")
+        Mix.Task.rerun("sbom.cyclonedx", ["-f", "-o", test_bom_path, "--only", "test"])
+        assert_received {:mix_shell, :info, ["* creating bom_test.cdx.json"]}
+
+        test_bom_content = File.read!(test_bom_path)
+
+        # Should include test dependencies
+        assert String.contains?(test_bom_content, "meck")
+        assert String.contains?(test_bom_content, "excoveralls")
+        assert String.contains?(test_bom_content, "circuits_gpio")
+
+        # Should include dependencies available in all envs
+        assert String.contains?(test_bom_content, "jason")
+
+        # Should include multi-env deps that include test
+        assert String.contains?(test_bom_content, "sweet_xml")
+
+        # Should NOT include dev-only dependencies
+        refute String.contains?(test_bom_content, "ex_doc")
+        refute String.contains?(test_bom_content, "dialyxir")
+
+        # Should NOT include prod-only dependencies
+        refute String.contains?(test_bom_content, "hackney")
+      end)
+    end
+
+    @tag :tmp_dir
+    @tag fixture_app: "filterable"
+    test "filters dependencies by targets option", %{app_path: app_path} do
+      Util.in_project(app_path, fn _mix_module ->
+        # Test filtering for host target
+        host_bom_path = Path.join(app_path, "bom_host.cdx.json")
+        Mix.Task.rerun("sbom.cyclonedx", ["-f", "-o", host_bom_path, "--targets", "host"])
+        assert_received {:mix_shell, :info, ["* creating bom_host.cdx.json"]}
+
+        host_bom_content = File.read!(host_bom_path)
+
+        # Should include host-targeted dependencies
+        assert String.contains?(host_bom_content, "phoenix")
+        assert String.contains?(host_bom_content, "phoenix_live_dashboard")
+
+        # Should include dependencies available for all targets
+        assert String.contains?(host_bom_content, "jason")
+        assert String.contains?(host_bom_content, "ex_doc")
+
+        # Should NOT include rpi-only dependencies
+        refute String.contains?(host_bom_content, "nerves")
+        refute String.contains?(host_bom_content, "circuits_gpio")
+
+        # Test filtering for rpi target
+        rpi_bom_path = Path.join(app_path, "bom_rpi.cdx.json")
+        Mix.Task.rerun("sbom.cyclonedx", ["-f", "-o", rpi_bom_path, "--targets", "rpi"])
+        assert_received {:mix_shell, :info, ["* creating bom_rpi.cdx.json"]}
+
+        rpi_bom_content = File.read!(rpi_bom_path)
+
+        # Should include rpi-targeted dependencies
+        assert String.contains?(rpi_bom_content, "nerves")
+        assert String.contains?(rpi_bom_content, "circuits_gpio")
+
+        # Should include dependencies available for all targets
+        assert String.contains?(rpi_bom_content, "jason")
+
+        # Should NOT include host-only dependencies
+        refute String.contains?(rpi_bom_content, "phoenix")
+        refute String.contains?(rpi_bom_content, "phoenix_live_dashboard")
+      end)
+    end
+
+    @tag :tmp_dir
+    @tag fixture_app: "filterable"
+    test "filters dependencies by combined only and targets options", %{app_path: app_path} do
+      Util.in_project(app_path, fn _mix_module ->
+        # Test filtering for dev + host combination
+        combined_bom_path = Path.join(app_path, "bom_dev_host.cdx.json")
+        Mix.Task.rerun("sbom.cyclonedx", ["-f", "-o", combined_bom_path, "--only", "dev", "--targets", "host"])
+        assert_received {:mix_shell, :info, ["* creating bom_dev_host.cdx.json"]}
+
+        combined_bom_content = File.read!(combined_bom_path)
+
+        # Should include dependencies that match both dev AND host
+        assert String.contains?(combined_bom_content, "phoenix_live_dashboard")
+
+        # Should include dependencies available in all envs and targets
+        assert String.contains?(combined_bom_content, "jason")
+
+        # Should include dev dependencies available for all targets
+        assert String.contains?(combined_bom_content, "ex_doc")
+        assert String.contains?(combined_bom_content, "dialyxir")
+
+        # Should include host dependencies available for all envs
+        assert String.contains?(combined_bom_content, "phoenix")
+
+        # Should NOT include rpi dependencies even if they're dev
+        refute String.contains?(combined_bom_content, "circuits_gpio")
+
+        # Should NOT include test dependencies even if they're host
+        refute String.contains?(combined_bom_content, "meck")
+
+        # Should NOT include prod-only or rpi-only dependencies
+        refute String.contains?(combined_bom_content, "hackney")
+        refute String.contains?(combined_bom_content, "nerves")
+      end)
+    end
   end
 end

--- a/test/sbom/cyclonedx_test.exs
+++ b/test/sbom/cyclonedx_test.exs
@@ -96,4 +96,21 @@ defmodule SBoM.CycloneDXTest do
       assert cannonicalize_bom(bom) == cannonicalize_bom(xml_decoded_bom)
     end
   end
+
+  test "classification option sets root component type" do
+    components = Fetcher.fetch()
+
+    # Default classification
+    bom_default = CycloneDX.bom(components)
+    assert bom_default.metadata.component.type == :CLASSIFICATION_APPLICATION
+
+    # Custom classification
+    bom_framework = CycloneDX.bom(components, classification: :CLASSIFICATION_FRAMEWORK)
+    assert bom_framework.metadata.component.type == :CLASSIFICATION_FRAMEWORK
+
+    # Dependencies remain LIBRARY
+    Enum.each(bom_framework.components, fn comp ->
+      assert comp.type == :CLASSIFICATION_LIBRARY
+    end)
+  end
 end

--- a/test/sbom/fetcher_test.exs
+++ b/test/sbom/fetcher_test.exs
@@ -5,6 +5,58 @@ defmodule SBoM.FetcherTest do
   use SBoM.FixtureCase, async: false
 
   alias SBoM.Fetcher
+  alias SBoM.Util
 
   doctest Fetcher
+
+  describe inspect(&Fetcher.fetch/0) do
+    @tag :tmp_dir
+    @tag fixture_app: "filterable"
+    test "correctly sets only and targets for dependencies", %{app_path: app_path} do
+      Util.in_project(app_path, fn _mix_module ->
+        deps = Fetcher.fetch()
+
+        # Dependencies with no restrictions (default [:*])
+        assert %{only: :*, targets: :*} = deps["jason"]
+
+        # Development only dependencies
+        assert %{only: [:dev], targets: :*} = deps["ex_doc"]
+        assert %{only: [:dev], targets: :*} = deps["dialyxir"]
+
+        # Test only dependencies
+        assert %{only: [:test], targets: :*} = deps["meck"]
+        assert %{only: [:test], targets: :*} = deps["excoveralls"]
+
+        # Production only dependencies
+        assert %{only: [:prod], targets: :*} = deps["hackney"]
+
+        # Multiple environments
+        assert %{only: [:dev, :test], targets: :*} = deps["sweet_xml"]
+        assert %{only: [:prod, :dev], targets: :*} = deps["telemetry"]
+
+        # Dependencies with targets
+        assert %{only: :*, targets: [:host]} = deps["phoenix"]
+        assert %{only: :*, targets: [:rpi]} = deps["nerves"]
+
+        # Dependencies with both only and targets
+        assert %{only: [:dev], targets: [:host]} = deps["phoenix_live_dashboard"]
+        assert %{only: [:dev, :test], targets: [:rpi]} = deps["circuits_gpio"]
+
+        # Optional dependencies
+        # Loaded in Runtime, so not optional in output
+        assert %{optional: false, only: :*, targets: :*} = deps["optional_dep"]
+        assert %{optional: true, only: [:dev], targets: :*} = deps["optional_dev_dep"]
+
+        # Runtime false dependencies
+        assert %{runtime: false, only: [:dev], targets: :*} = deps["mix_test_watch"]
+
+        # Complex combinations
+        assert %{
+                 optional: true,
+                 only: [:dev, :test],
+                 targets: [:host, :rpi]
+               } = deps["complex_dep"]
+      end)
+    end
+  end
 end


### PR DESCRIPTION
Restore support for CLI args from version 0.7.0 (`--only`, `--targets`, `--classification`) that were missing in the new implementation.
