### PR TITLE
Add Best Practices Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,7 @@
 [![.github/workflows/branch_main.yml](https://github.com/erlef/mix_sbom/actions/workflows/branch_main.yml/badge.svg)](https://github.com/erlef/mix_sbom/actions/workflows/branch_main.yml)
 [![Coverage Status](https://coveralls.io/repos/github/erlef/mix_sbom/badge.svg?branch=main)](https://coveralls.io/github/erlef/mix_sbom?branch=main)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/erlef/mix_sbom/badge)](https://scorecard.dev/viewer/?uri=github.com/erlef/mix_sbom)
-<!-- TODO: Do BPB
-[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/10438/badge)](https://www.bestpractices.dev/projects/10438)
--->
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/11509/badge)](https://www.bestpractices.dev/projects/11509)
 [![REUSE status](https://api.reuse.software/badge/github.com/erlef/mix_sbom)](https://api.reuse.software/info/github.com/erlef/mix_sbom)
 
 Generates a Software Bill-of-Materials (SBoM) for Mix projects, in [CycloneDX](https://cyclonedx.org)


### PR DESCRIPTION
Add the OpenSSF Best Practices “passing” badge to the project to surface its compliance status in the README.