### PR TITLE
Document Public Interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,11 @@
   SPDX-FileCopyrightText: 2025 Erlang Ecosystem Foundation
 -->
 
+<!-- ex_doc_ignore_start -->
 # SBoM
 
 > ⚠️ **Note**: This documentation is for the main branch. For the latest stable release, check [v0.7.0](https://github.com/erlef/mix_sbom/tree/v0.7.0).
+<!-- ex_doc_ignore_end -->
 
 [![EEF Security WG project](https://img.shields.io/badge/EEF-Security-black)](https://github.com/erlef/security-wg)
 [![.github/workflows/branch_main.yml](https://github.com/erlef/mix_sbom/actions/workflows/branch_main.yml/badge.svg)](https://github.com/erlef/mix_sbom/actions/workflows/branch_main.yml)
@@ -18,7 +20,9 @@
 Generates a Software Bill-of-Materials (SBoM) for Mix projects, in [CycloneDX](https://cyclonedx.org)
 format.
 
+<!-- ex_doc_ignore_start -->
 Full documentation can be found at [https://hexdocs.pm/sbom](https://hexdocs.pm/sbom).
+<!-- ex_doc_ignore_end -->
 
 For a quick demo of how this might be used, check out [this blog post](https://blog.voltone.net/post/24).
 

--- a/lib/mix/tasks/sbom.cyclonedx.ex
+++ b/lib/mix/tasks/sbom.cyclonedx.ex
@@ -4,9 +4,7 @@
 help =
   :mix
   |> SBoM.CLI.cli_def()
-  |> Optimus.Help.help([:cyclonedx], 80)
-  |> Enum.intersperse("\n")
-  |> IO.iodata_to_binary()
+  |> SBoM.Util.optimus_help_to_mix_docs([:cyclonedx])
 
 defmodule Mix.Tasks.Sbom.Cyclonedx do
   @shortdoc "Generates CycloneDX SBoM"

--- a/lib/sbom.ex
+++ b/lib/sbom.ex
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# SPDX-FileCopyrightText: 2025 Erlang Ecosystem Foundation
+
+readme_path = Path.join(__DIR__, "../README.md")
+
+readme_content =
+  readme_path
+  |> File.read!()
+  |> String.replace(~r/<!-- ex_doc_ignore_start -->.*?<!-- ex_doc_ignore_end -->/s, "")
+
+defmodule SBoM do
+  @moduledoc readme_content
+  @external_resource readme_path
+end

--- a/lib/sbom/cli.ex
+++ b/lib/sbom/cli.ex
@@ -3,11 +3,10 @@
 # SPDX-FileCopyrightText: 2025 Erlang Ecosystem Foundation
 
 defmodule SBoM.CLI do
-  @moduledoc """
-  Shared CLI logic for generating CycloneDX SBoMs.
+  @moduledoc false
 
-  Used by both the Mix task and escript implementations.
-  """
+  # Shared CLI logic for generating CycloneDX SBoMs.
+  # This module is used by both the Mix task and escript implementations.
 
   alias SBoM.CycloneDX
   alias SBoM.Fetcher
@@ -130,7 +129,7 @@ defmodule SBoM.CLI do
                 [
                   project_path: [
                     value_name: "PROJECT_PATH",
-                    help: "Path to the Mix project (defaults to current working directory)",
+                    help: "Path to the Mix project",
                     required: false,
                     default: &File.cwd!/0
                   ]
@@ -141,7 +140,7 @@ defmodule SBoM.CLI do
               value_name: "OUTPUT_PATH",
               short: "-o",
               long: "--output",
-              help: "Path to write the generated SBoM to (defaults to bom.cdx.json)",
+              help: "Path to write the generated SBoM to",
               required: false,
               parser: :string
             ],
@@ -149,7 +148,7 @@ defmodule SBoM.CLI do
               value_name: "SCHEMA_VERSION",
               short: "-s",
               long: "--schema",
-              help: "CycloneDX schema version to use (defaults to 1.6)",
+              help: "CycloneDX schema version to use",
               required: false,
               parser: &parse_schema/1,
               default: @default_schema
@@ -158,7 +157,7 @@ defmodule SBoM.CLI do
               value_name: "FORMAT",
               short: "-t",
               long: "--format",
-              help: "Output format, one of xml, json, protobuf (defaults to json)",
+              help: "Output format, one of xml, json, protobuf",
               required: false,
               parser: &parse_format/1
             ],
@@ -176,7 +175,7 @@ defmodule SBoM.CLI do
               value_name: "TARGETS",
               short: "-a",
               long: "--targets",
-              help: "Comma-separated list of Mix targets to include components from (defaults to all targets)",
+              help: "Comma-separated list of Mix targets to include components from",
               required: false,
               default: [:*],
               parser: &parse_atom/1,
@@ -186,7 +185,7 @@ defmodule SBoM.CLI do
               value_name: "CLASSIFICATION",
               short: "-c",
               long: "--classification",
-              help: "Specifies the type of application being described (defaults to application)",
+              help: "Specifies the type of application being described",
               required: false,
               default: @default_classification,
               parser: &parse_classification/1

--- a/lib/sbom/cyclonedx/json/encodable.ex
+++ b/lib/sbom/cyclonedx/json/encodable.ex
@@ -2,12 +2,12 @@
 # SPDX-FileCopyrightText: 2025 Erlang Ecosystem Foundation
 
 defprotocol SBoM.CycloneDX.JSON.Encodable do
-  @moduledoc """
-  Protocol for converting CycloneDX structs to JSON-encodable data structures.
+  @moduledoc false
 
-  This protocol provides custom control over JSON encoding while maintaining
-  compatibility with Protobuf's built-in JSON encoding for generated structs.
-  """
+  # Protocol for converting CycloneDX structs to JSON-encodable data structures.
+  #
+  # This protocol provides custom control over JSON encoding while maintaining
+  # compatibility with Protobuf's built-in JSON encoding for generated structs.
 
   @fallback_to_any true
 

--- a/lib/sbom/cyclonedx/xml/encodable.ex
+++ b/lib/sbom/cyclonedx/xml/encodable.ex
@@ -2,6 +2,8 @@
 # SPDX-FileCopyrightText: 2025 Erlang Ecosystem Foundation
 
 defprotocol SBoM.CycloneDX.XML.Encodable do
+  @moduledoc false
+
   @doc """
   Converts a CycloneDX struct to an XML element tuple suitable for :xmerl.
 

--- a/lib/sbom/cyclonedx/xml/helpers.ex
+++ b/lib/sbom/cyclonedx/xml/helpers.ex
@@ -2,9 +2,9 @@
 # SPDX-FileCopyrightText: 2025 Erlang Ecosystem Foundation
 
 defmodule SBoM.CycloneDX.XML.Helpers do
-  @moduledoc """
-  Generic XML structure building helpers for CycloneDX encoding.
-  """
+  @moduledoc false
+
+  # Generic XML structure building helpers for CycloneDX encoding.
 
   alias SBoM.CycloneDX.XML.Encodable
 

--- a/lib/sbom/escript.ex
+++ b/lib/sbom/escript.ex
@@ -2,9 +2,9 @@
 # SPDX-FileCopyrightText: 2025 Erlang Ecosystem Foundation
 
 defmodule SBoM.Escript do
-  @moduledoc """
-  Escript entry point for generating CycloneDX SBoMs.
-  """
+  @moduledoc false
+
+  # Escript entry point for generating CycloneDX SBoMs.
 
   alias SBoM.CLI
 

--- a/lib/sbom/fetcher.ex
+++ b/lib/sbom/fetcher.ex
@@ -2,17 +2,17 @@
 # SPDX-FileCopyrightText: 2025 Erlang Ecosystem Foundation
 
 defmodule SBoM.Fetcher do
-  @moduledoc """
-  Defines the behaviour for manifest fetchers and provides an entry point to collect
-  dependency data from multiple sources.
+  @moduledoc false
 
-  The built-in fetchers include:
-
-    * `SBoM.Fetcher.MixFile` — parses `mix.exs`
-    * `SBoM.Fetcher.MixLock` — parses `mix.lock`
-    * `SBoM.Fetcher.MixRuntime` — inspects runtime dependency
-      graph
-  """
+  # Defines the behaviour for manifest fetchers and provides an entry point to
+  # collect dependency data from multiple sources.
+  #
+  # The built-in fetchers include:
+  #
+  #   * `SBoM.Fetcher.MixFile` — parses `mix.exs`
+  #   * `SBoM.Fetcher.MixLock` — parses `mix.lock`
+  #   * `SBoM.Fetcher.MixRuntime` — inspects runtime dependency
+  #     graph
 
   alias SBoM.SCM
 

--- a/lib/sbom/fetcher/mix_file.ex
+++ b/lib/sbom/fetcher/mix_file.ex
@@ -2,14 +2,14 @@
 # SPDX-FileCopyrightText: 2025 Erlang Ecosystem Foundation
 
 defmodule SBoM.Fetcher.MixFile do
-  @moduledoc """
-  A `SBoM.Fetcher` implementation that extracts dependencies
-  from the current project's `mix.exs` file.
+  @moduledoc false
 
-  This module is responsible for reading and normalizing direct dependencies
-  defined in the project configuration, returning them in a standard format
-  expected by the submission tool.
-  """
+  #  A `SBoM.Fetcher` implementation that extracts dependencies
+  # from the current project's `mix.exs` file.
+  #
+  # This module is responsible for reading and normalizing direct dependencies
+  # defined in the project configuration, returning them in a standard format
+  # expected by the submission tool.
 
   @behaviour SBoM.Fetcher
 

--- a/lib/sbom/fetcher/mix_lock.ex
+++ b/lib/sbom/fetcher/mix_lock.ex
@@ -2,12 +2,12 @@
 # SPDX-FileCopyrightText: 2025 Erlang Ecosystem Foundation
 
 defmodule SBoM.Fetcher.MixLock do
-  @moduledoc """
-  Fetches dependencies from the `mix.lock` file.
+  @moduledoc false
 
-  This module implements the `SBoM.Fetcher` behaviour to extract
-  locked dependencies and convert them into the expected internal format.
-  """
+  # Fetches dependencies from the `mix.lock` file.
+  #
+  # This module implements the `SBoM.Fetcher` behaviour to extract
+  # locked dependencies and convert them into the expected internal format.
 
   @behaviour SBoM.Fetcher
 

--- a/lib/sbom/fetcher/mix_runtime.ex
+++ b/lib/sbom/fetcher/mix_runtime.ex
@@ -2,13 +2,12 @@
 # SPDX-FileCopyrightText: 2025 Erlang Ecosystem Foundation
 
 defmodule SBoM.Fetcher.MixRuntime do
-  @moduledoc """
-  Fetches dependencies from the compiled Mix project at runtime.
-
-  This fetcher uses `Mix.Project.deps_tree/1` and related project metadata to
-  collect runtime dependency information including versions, SCMs, and
-  relationships.
-  """
+  @moduledoc false
+  # Fetches dependencies from the compiled Mix project at runtime.
+  #
+  # This fetcher uses `Mix.Project.deps_tree/1` and related project metadata to
+  # collect runtime dependency information including versions, SCMs, and
+  # relationships.
 
   @behaviour SBoM.Fetcher
 

--- a/lib/sbom/scm.ex
+++ b/lib/sbom/scm.ex
@@ -2,16 +2,16 @@
 # SPDX-FileCopyrightText: 2025 Erlang Ecosystem Foundation
 
 defmodule SBoM.SCM do
-  @moduledoc """
-  Defines the behavior and helper types for working with source control managers
-  (SCMs) in the Mix dependency submission context.
+  @moduledoc false
 
-  SCM implementations are responsible for generating package URLs (`purl`) and
-  extracting dependency metadata from `mix.lock` or `mix.exs`.
-
-  Implementations must live under `SBoM.SCM.[NAME]` and match
-  the name of the corresponding module in `Mix.SCM.available/0`.
-  """
+  # Defines the behavior and helper types for working with source control managers
+  # (SCMs) in the Mix dependency submission context.
+  #
+  # SCM implementations are responsible for generating package URLs (`purl`) and
+  # extracting dependency metadata from `mix.lock` or `mix.exs`.
+  #
+  # Implementations must live under `SBoM.SCM.[NAME]` and match
+  # the name of the corresponding module in `Mix.SCM.available/0`.
 
   @typedoc """
   Lock for the dependency as a list.

--- a/lib/sbom/scm/hex/scm.ex
+++ b/lib/sbom/scm/hex/scm.ex
@@ -2,12 +2,12 @@
 # SPDX-FileCopyrightText: 2025 Erlang Ecosystem Foundation
 
 defmodule SBoM.SCM.Hex.SCM do
-  @moduledoc """
-  SCM implementation for Hex packages.
+  @moduledoc false
 
-  Handles the conversion of Hex dependencies into `purl` format and extraction
-  of dependency information from `mix.exs` and `mix.lock`.
-  """
+  # SCM implementation for Hex packages.
+  #
+  # Handles the conversion of Hex dependencies into `purl` format and extraction
+  # of dependency information from `mix.exs` and `mix.lock`.
 
   @behaviour SBoM.SCM
 

--- a/lib/sbom/scm/mix/scm/git.ex
+++ b/lib/sbom/scm/mix/scm/git.ex
@@ -2,13 +2,13 @@
 # SPDX-FileCopyrightText: 2025 Erlang Ecosystem Foundation
 
 defmodule SBoM.SCM.Mix.SCM.Git do
-  @moduledoc """
-  SCM implementation for Git-based Mix dependencies.
+  @moduledoc false
 
-  Handles conversion of Git dependencies declared in `mix.exs` or found in
-  `mix.lock` into package URLs (purl). Falls back to a generic purl format if
-  the repository URL does not represent a specific purl type like `pkg:github`.
-  """
+  # SCM implementation for Git-based Mix dependencies.
+  #
+  # Handles conversion of Git dependencies declared in `mix.exs` or found in
+  # `mix.lock` into package URLs (purl). Falls back to a generic purl format if
+  # the repository URL does not represent a specific purl type like `pkg:github`.
 
   @behaviour SBoM.SCM
 

--- a/lib/sbom/scm/mix/scm/path.ex
+++ b/lib/sbom/scm/mix/scm/path.ex
@@ -2,12 +2,12 @@
 # SPDX-FileCopyrightText: 2025 Erlang Ecosystem Foundation
 
 defmodule SBoM.SCM.Mix.SCM.Path do
-  @moduledoc """
-  SCM implementation for path-based Mix dependencies.
+  @moduledoc false
 
-  Generates a generic `purl` for dependencies declared with `:path` in
-  `mix.exs`.
-  """
+  # SCM implementation for path-based Mix dependencies.
+  #
+  # Generates a generic `purl` for dependencies declared with `:path` in
+  # `mix.exs`.
 
   @behaviour SBoM.SCM
 

--- a/lib/sbom/scm/system.ex
+++ b/lib/sbom/scm/system.ex
@@ -2,10 +2,10 @@
 # SPDX-FileCopyrightText: 2025 Erlang Ecosystem Foundation
 
 defmodule SBoM.SCM.System do
-  @moduledoc """
-  A `Mix.SCM` implementation that looks up the system dependencies.
-  (Erlang, Elixir, Hex, etc.)
-  """
+  @moduledoc false
+
+  # A `Mix.SCM` implementation that looks up the system dependencies.
+  # (Erlang, Elixir, Hex, etc.)
 
   @behaviour Mix.SCM
 
@@ -79,9 +79,9 @@ defmodule SBoM.SCM.System do
 end
 
 defmodule SBoM.SCM.SBoM.SCM.System do
-  @moduledoc """
-  `SBoM.SCM` implementation for system dependencies.
-  """
+  @moduledoc false
+
+  # `SBoM.SCM` implementation for system dependencies.
 
   @behaviour SBoM.SCM
 

--- a/lib/sbom/util.ex
+++ b/lib/sbom/util.ex
@@ -67,4 +67,23 @@ defmodule SBoM.Util do
   def hash_app_name(seed) do
     seed |> :erlang.crc32() |> Integer.digits(26) |> Enum.map(&(&1 + ?a)) |> List.to_string()
   end
+
+  @spec optimus_help_to_mix_docs(Optimus.t(), Optimus.subcommand_path()) :: String.t()
+  def optimus_help_to_mix_docs(optimus, subcommand) do
+    optimus
+    |> Optimus.Help.help(subcommand, 10_000)
+    |> Enum.map(fn
+      "USAGE:" -> "## Usage"
+      "FLAGS:" -> "## Flags"
+      "OPTIONS:" -> "## Options"
+      "    -" <> rest -> " * -#{rest}"
+      other -> other
+    end)
+    |> Enum.intersperse("\n")
+    |> IO.iodata_to_binary()
+    |> String.replace(~r/\(default: (.+)\)/, "(default: `\\1`)")
+    |> String.replace(~r/ --([a-z]+)/, " `-\\1`")
+    |> String.replace(~r/ -([a-z])/, " `-\\1`")
+    |> String.replace(~r/(\[--.+\])/U, "\\\n      \\1")
+  end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -144,8 +144,7 @@ defmodule SBoM.MixProject do
 
   defp docs do
     [
-      main: "readme",
-      extras: ["README.md"],
+      main: "SBoM",
       source_ref: "v#{@version}"
     ]
   end


### PR DESCRIPTION
Remove `@moduledoc` from internal, non-public modules to make their status clear and keep them outside semver guarantees. Integrate the README into the main module’s docs so the primary documentation is shown directly in the generated docs.
