### PR TITLE
Normalize atom keys in Links

### DIFF
--- a/lib/sbom/cyclonedx.ex
+++ b/lib/sbom/cyclonedx.ex
@@ -327,9 +327,13 @@ defmodule SBoM.CycloneDX do
           SBoM.CLI.schema_version()
         ) :: [external_reference()]
   defp links_references(links, version) do
-    Enum.map(links, fn {name, url} ->
+    alias SBoM.Fetcher.Links
+
+    links
+    |> Links.normalize_link_keys()
+    |> Enum.map(fn {name, url} ->
       type =
-        case String.downcase(name) do
+        case name do
           source
           when source in ["github", "gitlab", "git", "source", "repository", "bitbucket"] ->
             :EXTERNAL_REFERENCE_TYPE_VCS

--- a/lib/sbom/fetcher/links.ex
+++ b/lib/sbom/fetcher/links.ex
@@ -4,7 +4,7 @@
 defmodule SBoM.Fetcher.Links do
   @moduledoc false
 
-  @type t() :: %{optional(String.t()) => String.t()}
+  @type t() :: %{optional(atom() | String.t()) => String.t()}
 
   @source_url_names [
     "github",
@@ -15,12 +15,22 @@ defmodule SBoM.Fetcher.Links do
     "bitbucket"
   ]
 
-  @spec source_url(links :: %{String.t() => String.t()}) :: String.t() | nil
+  @spec source_url(links :: t()) :: String.t() | nil
   def source_url(links) do
-    Enum.find_value(links, fn {name, url} ->
-      if String.downcase(name) in @source_url_names do
+    links
+    |> normalize_link_keys()
+    |> Enum.find_value(fn {name, url} ->
+      if name in @source_url_names do
         url
       end
     end)
   end
+
+  @spec normalize_link_keys(links :: t()) :: %{String.t() => String.t()}
+  def normalize_link_keys(links) do
+    Map.new(links, fn {name, value} ->
+      {name |> to_string() |> String.downcase(), value}
+    end)
+  end
+
 end

--- a/lib/sbom/fetcher/links.ex
+++ b/lib/sbom/fetcher/links.ex
@@ -32,5 +32,4 @@ defmodule SBoM.Fetcher.Links do
       {name |> to_string() |> String.downcase(), value}
     end)
   end
-
 end

--- a/test/fixtures/sample1/mix.exs
+++ b/test/fixtures/sample1/mix.exs
@@ -7,7 +7,13 @@ defmodule Sample1.MixProject do
       version: "0.1.0",
       elixir: "~> 1.8",
       start_permanent: Mix.env() == :prod,
-      deps: deps()
+      deps: deps(),
+      package: [
+        links: %{
+          Github: "https://github.com/sample1",
+          Changelog: "https://hexdocs.pm/sample1/changelog.html"
+        }
+      ]
     ]
   end
 


### PR DESCRIPTION
This PR normalizes all keys in `config[:links] || config[:package][:links]` to strings to ensure consistent handling, even when users provide atom keys in their Mix configuration.