### PR TITLE
STDOUT Task Output

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ output; the task should normally be run in the default (dev) environment*
 ### Available Options
 
 - `-o, --output PATH`: Output file path (defaults to `bom.cdx.json`)
+  Use `-` for STDOUT
 - `-s, --schema VERSION`: CycloneDX schema version - 1.3, 1.4, 1.5, 1.6, 1.7
   (defaults to 1.6)
 - `-t, --format FORMAT`: Output format - xml, json, protobuf (defaults to json)

--- a/coveralls.json
+++ b/coveralls.json
@@ -1,6 +1,7 @@
 {
   "skip_files": [
     "test",
-    "lib\/sbom\/cyclonedx\/v.+"
+    "lib\/sbom\/cyclonedx\/v.+",
+    "lib/sbom/escript.ex"
   ]
 }

--- a/lib/sbom/cli.ex
+++ b/lib/sbom/cli.ex
@@ -99,6 +99,13 @@ defmodule SBoM.CLI do
   end
 
   @spec write_file(iodata, Path.t(), boolean()) :: :ok
+  defp write_file(content, output_path, force)
+
+  defp write_file(content, "-", _force) do
+    IO.binwrite(content)
+    :ok
+  end
+
   defp write_file(content, output_path, force) do
     if Mix.Generator.create_file(output_path, content, force: force) do
       :ok
@@ -141,7 +148,7 @@ defmodule SBoM.CLI do
               value_name: "OUTPUT_PATH",
               short: "-o",
               long: "--output",
-              help: "Path to write the generated SBoM to",
+              help: "Path to write the generated SBoM to. Use '-' for STDOUT",
               required: false,
               parser: :string
             ],


### PR DESCRIPTION
Allow using "-" as the output argument to print the BOM to STDOUT instead of writing it to a file.