### PR TITLE
feat: add component description field to SBOM output

### DIFF
--- a/lib/sbom/cyclonedx.ex
+++ b/lib/sbom/cyclonedx.ex
@@ -273,6 +273,7 @@ defmodule SBoM.CycloneDX do
     bom_struct(:Component, schema_version,
       type: :CLASSIFICATION_LIBRARY,
       name: name,
+      description: component[:description],
       version:
         case schema_version do
           "1.3" -> component[:version] || component[:version_requirement] || "unknown"

--- a/lib/sbom/fetcher.ex
+++ b/lib/sbom/fetcher.ex
@@ -35,7 +35,8 @@ defmodule SBoM.Fetcher do
           optional(:licenses) => [String.t()],
           optional(:root) => boolean(),
           optional(:source_url) => String.t(),
-          optional(:links) => SBoM.Fetcher.Links.t()
+          optional(:links) => SBoM.Fetcher.Links.t(),
+          optional(:description) => String.t()
         }
 
   @doc """

--- a/lib/sbom/metadata.ex
+++ b/lib/sbom/metadata.ex
@@ -14,12 +14,13 @@ defmodule SBoM.Metadata do
 
   alias SBoM.Fetcher.Links
 
-  @metadata_keys [:licenses, :source_url, :links]
+  @metadata_keys [:licenses, :source_url, :links, :description]
 
   @type metadata() :: %{
           optional(:licenses) => [String.t()],
           optional(:source_url) => String.t() | nil,
-          optional(:links) => Links.t()
+          optional(:links) => Links.t(),
+          optional(:description) => String.t() | nil
         }
 
   @doc """
@@ -28,7 +29,7 @@ defmodule SBoM.Metadata do
   ## Examples
 
       iex> SBoM.Metadata.keys()
-      [:licenses, :source_url, :links]
+      [:licenses, :source_url, :links, :description]
   """
   @spec keys() :: list(atom())
   def keys, do: @metadata_keys
@@ -44,20 +45,23 @@ defmodule SBoM.Metadata do
       iex> config = [
       ...>   licenses: ["Apache-2.0"],
       ...>   source_url: "https://github.com/example/repo",
-      ...>   links: %{"github" => "https://github.com/example/repo"}
+      ...>   links: %{"github" => "https://github.com/example/repo"},
+      ...>   description: "A description of the example package"
       ...> ]
       ...>
       ...> SBoM.Metadata.from_mix_config(config)
       %{
         licenses: ["Apache-2.0"],
         source_url: "https://github.com/example/repo",
-        links: %{"github" => "https://github.com/example/repo"}
+        links: %{"github" => "https://github.com/example/repo"},
+        description: "A description of the example package"
       }
 
       iex> config = [
       ...>   package: [
       ...>     licenses: ["MIT"],
-      ...>     links: %{"homepage" => "https://example.com"}
+      ...>     links: %{"homepage" => "https://example.com"},
+      ...>     description: "A description of the example package"
       ...>   ]
       ...> ]
       ...>
@@ -65,13 +69,16 @@ defmodule SBoM.Metadata do
       %{
         licenses: ["MIT"],
         source_url: nil,
-        links: %{"homepage" => "https://example.com"}
+        links: %{"homepage" => "https://example.com"},
+        description: "A description of the example package"
       }
   """
   @spec from_mix_config(Keyword.t()) :: metadata()
   def from_mix_config(config) when is_list(config) do
     links = config[:links] || config[:package][:links] || %{}
     normalized_links = Links.normalize_link_keys(links)
+
+    description = config[:description] || config[:package][:description]
 
     licenses = config[:licenses] || config[:package][:licenses] || []
     licenses = List.wrap(licenses)
@@ -81,7 +88,8 @@ defmodule SBoM.Metadata do
     %{
       licenses: licenses,
       source_url: source_url,
-      links: normalized_links
+      links: normalized_links,
+      description: description
     }
   end
 
@@ -164,6 +172,7 @@ defmodule SBoM.Metadata do
   def from_hex_payload(payload) when is_map(payload) do
     meta = payload["meta"] || %{}
     links = meta["links"] || %{}
+    description = meta["description"]
 
     # Normalize links first (keys may be strings with mixed case from Hex API)
     normalized_links = Links.normalize_link_keys(links)
@@ -194,7 +203,8 @@ defmodule SBoM.Metadata do
     metadata = %{
       licenses: licenses,
       source_url: source_url,
-      links: normalized_links
+      links: normalized_links,
+      description: description
     }
 
     # Remove only empty/nil values, keep non-empty ones

--- a/test/sbom/metadata_test.exs
+++ b/test/sbom/metadata_test.exs
@@ -10,7 +10,7 @@ defmodule SBoM.MetadataTest do
 
   describe "keys/0" do
     test "returns the list of metadata keys" do
-      assert Metadata.keys() == [:licenses, :source_url, :links]
+      assert Metadata.keys() == [:licenses, :source_url, :links, :description]
       assert is_list(Metadata.keys())
       assert Enum.all?(Metadata.keys(), &is_atom/1)
     end
@@ -21,7 +21,8 @@ defmodule SBoM.MetadataTest do
       metadata = %{
         licenses: ["MIT"],
         source_url: "https://example.com",
-        links: %{"homepage" => "https://example.com"}
+        links: %{"homepage" => "https://example.com"},
+        description: "A test package"
       }
 
       # All keys should be present in the metadata map

--- a/test/support/dependency_generators.ex
+++ b/test/support/dependency_generators.ex
@@ -193,6 +193,17 @@ defmodule SBoM.DependencyGenerators do
   end
 
   @doc """
+  Generates description strings.
+  """
+  @spec description() :: StreamData.t(String.t() | nil)
+  def description do
+    frequency([
+      {3, constant(nil)},
+      {7, string(:printable, min_length: 10, max_length: 100)}
+    ])
+  end
+
+  @doc """
   Generates links map for SBoM.Fetcher.Links.t().
   """
   @spec links() :: StreamData.t(%{String.t() => String.t()})
@@ -237,6 +248,7 @@ defmodule SBoM.DependencyGenerators do
   def hex_dependency do
     gen all(
           app <- app_name(),
+          description <- description(),
           version <- version_string(),
           req <- requirement_string(),
           repo <- member_of(["hexpm", "hexpm:myorg", "private"]),
@@ -288,6 +300,7 @@ defmodule SBoM.DependencyGenerators do
       |> maybe_put(:root, root)
       |> maybe_put(:source_url, source_url)
       |> maybe_put(:links, links)
+      |> maybe_put(:description, description)
     end
   end
 
@@ -298,6 +311,7 @@ defmodule SBoM.DependencyGenerators do
   def git_dependency do
     gen all(
           app <- app_name(),
+          description <- description(),
           git_url <- git_url(),
           version <- version_string(),
           req <- requirement_string(),
@@ -337,6 +351,7 @@ defmodule SBoM.DependencyGenerators do
       |> maybe_put(:licenses, licenses)
       |> maybe_put(:root, root)
       |> maybe_put(:links, links)
+      |> maybe_put(:description, description)
     end
   end
 
@@ -348,6 +363,7 @@ defmodule SBoM.DependencyGenerators do
   def path_dependency do
     gen all(
           app <- app_name(),
+          description <- description(),
           path <- file_path(),
           version <- version_string(),
           req <- requirement_string(),
@@ -382,6 +398,7 @@ defmodule SBoM.DependencyGenerators do
       |> maybe_put(:root, root)
       |> maybe_put(:source_url, source_url)
       |> maybe_put(:links, links)
+      |> maybe_put(:description, description)
     end
   end
 
@@ -393,6 +410,7 @@ defmodule SBoM.DependencyGenerators do
   def system_dependency do
     gen all(
           app <- system_app_name(),
+          description <- description(),
           version <- frequency([{7, constant(nil)}, {3, version_string()}]),
           # System deps are never optional
           optional <- constant(false),
@@ -426,6 +444,7 @@ defmodule SBoM.DependencyGenerators do
       |> maybe_put(:licenses, licenses)
       |> maybe_put(:root, root)
       |> maybe_put(:links, links)
+      |> maybe_put(:description, description)
     end
   end
 


### PR DESCRIPTION
Add support for a `description` field on components so their purpose can be captured in the BOM.

https://github.com/stritzinger/sosef/issues/27