### PR TITLE
XML Decoding Unicode Fix

### DIFF
--- a/lib/sbom/cyclonedx/xml.ex
+++ b/lib/sbom/cyclonedx/xml.ex
@@ -34,7 +34,8 @@ defmodule SBoM.CycloneDX.XML do
     {root_element, []} =
       string
       |> binary_part(bom_length, input_length - bom_length)
-      |> :unicode.characters_to_list(encoding)
+      |> :unicode.characters_to_binary(encoding)
+      |> :erlang.binary_to_list()
       |> :xmerl_scan.string(validation: :schema)
 
     version = detect_version(root_element)


### PR DESCRIPTION
Fix binary-to-codepoints conversion for non–Latin-1 characters when decoding XML. The bug was uncovered by property tests using the new description field.

Adresses Property Test Issue identified in #54