### PR TITLE
refactor: improve bom-ref format for readability

### DIFF
--- a/lib/sbom/cyclonedx.ex
+++ b/lib/sbom/cyclonedx.ex
@@ -430,7 +430,7 @@ defmodule SBoM.CycloneDX do
   @spec generate_bom_ref(Purl.t()) :: String.t()
   defp generate_bom_ref(purl) do
     hash = purl |> to_string() |> :erlang.phash2()
-    "urn:otp:component:#{purl.name}:#{hash}"
+    "urn:otp:component:#{purl.name}:#{purl.type}:#{hash}"
   end
 
   @spec tool(SBoM.CLI.schema_version()) :: tool() | component()

--- a/test/sbom/cyclonedx_test.exs
+++ b/test/sbom/cyclonedx_test.exs
@@ -191,4 +191,32 @@ defmodule SBoM.CycloneDXTest do
         end
     end
   end
+
+  describe "bom_ref generation" do
+    test "generates readable bom_ref for components" do
+      components = Fetcher.fetch()
+      bom = CycloneDX.bom(components)
+
+      Enum.each(bom.components, fn comp ->
+        assert String.starts_with?(comp.bom_ref, "urn:otp:component:")
+
+        cond do
+          String.contains?(comp.purl || "", "pkg:hex/") ->
+            assert String.contains?(comp.bom_ref, ":hex:")
+
+          String.contains?(comp.purl || "", "pkg:otp/") ->
+            assert String.contains?(comp.bom_ref, ":otp:")
+
+          String.contains?(comp.purl || "", "pkg:github/") ->
+            assert String.contains?(comp.bom_ref, ":github:")
+
+          String.contains?(comp.purl || "", "pkg:generic/") ->
+            assert String.contains?(comp.bom_ref, ":generic:")
+
+          true ->
+            :ok
+        end
+      end)
+    end
+  end
 end


### PR DESCRIPTION
Add PURL types to BOM refs to make the references clearer and improve readability for human consumers.

https://github.com/stritzinger/sosef/issues/27