### PR TITLE
Fix Flaky Tests

### DIFF
--- a/lib/sbom/cyclonedx.ex
+++ b/lib/sbom/cyclonedx.ex
@@ -414,7 +414,7 @@ defmodule SBoM.CycloneDX do
   defp attach_dependencies(components, version) do
     for {_name, component_data} <- components do
       dependency_refs =
-        component_data.dependencies
+        component_data[:dependencies]
         |> List.wrap()
         |> Enum.map(fn dep_purl ->
           bom_struct(:Dependency, version, ref: generate_bom_ref(dep_purl))

--- a/test/sbom/cpe_test.exs
+++ b/test/sbom/cpe_test.exs
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: 2025 Erlang Ecosystem Foundation
 
 defmodule SBoM.CPETest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
 
   alias SBoM.CPE
 

--- a/test/sbom/cyclonedx_test.exs
+++ b/test/sbom/cyclonedx_test.exs
@@ -145,8 +145,16 @@ defmodule SBoM.CycloneDXTest do
   describe "pretty JSON encoding (OTP-dependent)" do
     @tag :tmp_dir
     test "behaves correctly on this OTP", %{tmp_dir: tmp_dir} do
-      components = Fetcher.fetch()
-      bom = CycloneDX.bom(components)
+      [raw_dependencies] = Enum.take(DependencyGenerators.dependency_map(), 1)
+
+      atom_dependencies =
+        Map.new(raw_dependencies, fn {app_string, dep} ->
+          {String.to_existing_atom(app_string), dep}
+        end)
+
+      dependencies = Fetcher.transform_all(atom_dependencies)
+
+      bom = CycloneDX.bom(dependencies)
 
       pretty = CycloneDX.encode(bom, :json, true)
 
@@ -163,8 +171,16 @@ defmodule SBoM.CycloneDXTest do
       {:module, :xmerl_xml_indent} ->
         @tag :tmp_dir
         test "prints XML", %{tmp_dir: tmp_dir} do
-          components = Fetcher.fetch()
-          bom = CycloneDX.bom(components)
+          [raw_dependencies] = Enum.take(DependencyGenerators.dependency_map(), 1)
+
+          atom_dependencies =
+            Map.new(raw_dependencies, fn {app_string, dep} ->
+              {String.to_existing_atom(app_string), dep}
+            end)
+
+          dependencies = Fetcher.transform_all(atom_dependencies)
+
+          bom = CycloneDX.bom(dependencies)
 
           pretty = CycloneDX.encode(bom, :xml, true)
 


### PR DESCRIPTION
Fix flaky tests by running only async-safe tests in parallel and tightening two tests to focus on their intended behavior. This removes cross-test interference and stabilizes the suite.
