### PR TITLE
Fix Umbrella Dependencies & Name

### DIFF
--- a/lib/sbom/fetcher.ex
+++ b/lib/sbom/fetcher.ex
@@ -249,7 +249,7 @@ defmodule SBoM.Fetcher do
   defp package_url(dependency, app) do
     fallback =
       Purl.new!(%Purl{
-        type: "generic",
+        type: "otp",
         name: Atom.to_string(app),
         version: dependency[:version]
       })

--- a/test/sbom/fetcher_test.exs
+++ b/test/sbom/fetcher_test.exs
@@ -59,4 +59,24 @@ defmodule SBoM.FetcherTest do
       end)
     end
   end
+
+  @tag :tmp_dir
+  @tag fixture_app: "umbrella"
+  test "does umbrella correctly", %{app_path: app_path, app_name: app_name} do
+    Util.in_project(app_path, fn _mix_module ->
+      app_name_string = Atom.to_string(app_name)
+
+      assert %{
+               ^app_name_string => %{
+                 dependencies: [
+                   %Purl{name: "elixir", type: "otp"},
+                   %Purl{name: "credo", type: "hex"},
+                   %Purl{name: "child_app_name_to_replace", type: "otp"}
+                 ],
+                 version: "0.0.0-dev"
+               },
+               "child_app_name_to_replace" => %{}
+             } = Fetcher.fetch()
+    end)
+  end
 end

--- a/test/support/fixture_case.ex
+++ b/test/support/fixture_case.ex
@@ -17,9 +17,9 @@ defmodule SBoM.FixtureCase do
     on_exit(fn -> Mix.Project.clear_deps_cache() end)
 
     if tags[:tmp_dir] && tags[:fixture_app] do
-      app_name = prepare_fixture(tags[:fixture_app], tags[:tmp_dir])
+      {app_name, dest_dir} = prepare_fixture(tags[:fixture_app], tags[:tmp_dir])
 
-      {:ok, app_name: app_name, app_path: tags[:tmp_dir]}
+      {:ok, app_name: app_name, app_path: dest_dir}
     else
       :ok
     end
@@ -27,19 +27,22 @@ defmodule SBoM.FixtureCase do
 
   @spec prepare_fixture(fixture_app :: String.t(), dest_dir :: Path.t()) :: :ok
   def prepare_fixture(fixture_app, dest_dir) do
-    fixture_app |> app_fixture_path() |> File.cp_r!(dest_dir)
-
-    mix_file_path = Path.join(dest_dir, "mix.exs")
-
     # Safe: Atom is unique on prupose, but that's fine for tests
     # credo:disable-for-next-line Credo.Check.Warning.UnsafeToAtom
     app_name = dest_dir |> hash_app_name() |> String.to_atom()
+
+    dest_dir = Path.join(dest_dir, Atom.to_string(app_name))
+    File.mkdir_p!(dest_dir)
+
+    fixture_app |> app_fixture_path() |> File.cp_r!(dest_dir)
+
+    mix_file_path = Path.join(dest_dir, "mix.exs")
 
     if File.exists?(mix_file_path) do
       rewrite_app_name(mix_file_path, app_name)
     end
 
-    app_name
+    {app_name, dest_dir}
   end
 
   @spec app_fixture_path(app :: String.t()) :: Path.t()


### PR DESCRIPTION
When generating an SBOM for an umbrella project, the name and dependencies of the umbrella application itself were missing. This only affected SBOMs generated at the umbrella level, not per-child. The change adds the missing metadata so umbrella-level SBOMs are complete.
