### PR TITLE
Use ORT to generate SBoM instead of REUSE

### DIFF
--- a/.github/workflows/branch_main.yml
+++ b/.github/workflows/branch_main.yml
@@ -63,6 +63,18 @@ jobs:
 
     uses: ./.github/workflows/part_smoke_test.yml
 
+  attest_sbom:
+    name: "Attest SBOM"
+
+    needs: ["build", "licensing", "docs"]
+
+    permissions:
+      id-token: write
+      contents: read
+      attestations: write
+
+    uses: ./.github/workflows/part_attest_sbom.yml
+
   dependency_submission:
     name: "Mix Dependency Submission"
 

--- a/.github/workflows/part_attest_sbom.yml
+++ b/.github/workflows/part_attest_sbom.yml
@@ -1,0 +1,53 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# SPDX-FileCopyrightText: 2026 Erlang Ecosystem Foundation
+
+on:
+  workflow_call: {}
+
+name: "Attest SBOM"
+
+permissions:
+  contents: read
+
+jobs:
+  attest:
+    name: "Attest Build Artifacts with SBOM"
+
+    runs-on: ubuntu-latest
+
+    permissions:
+      id-token: write
+      contents: read
+      attestations: write
+
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@20cf305ff2072d973412fa9b1e3a4f227bda3c76 # v2.14.0
+        with:
+          egress-policy: audit
+
+      - name: "Download Docs Artifact"
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          name: docs
+          path: .
+
+      - name: "Download Binary Artifact"
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          name: binary
+          path: .
+
+      - name: "Download Source SBoM Artifact"
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          name: sbom
+          path: .
+
+      - name: "Attest build artifacts with SBOM"
+        uses: actions/attest-sbom@115c3be05ff3974bcbd596578934b3f9ce39bf68 # v2.2.0
+        with:
+          subject-path: |
+            docs.tar.gz
+            mix_sbom_*
+          sbom-path: sbom.spdx.json

--- a/.github/workflows/part_licensensing.yml
+++ b/.github/workflows/part_licensensing.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   sbom:
-    name: "Generate Source SBoM"
+    name: "Generate SBoM"
 
     runs-on: ubuntu-latest
 
@@ -30,34 +30,88 @@ jobs:
         uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
         with:
           egress-policy: audit
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      
-      - name: REUSE SPDX SBOM
-        uses: fsfe/reuse-action@676e2d560c9a403aa252096d99fcab3e1132b0f5 # v6.0.0
         with:
-          args: spdx -o source_sbom.spdx --creator-person "${{ github.actor }}" --creator-organization "Erlang Ecosystem Foundation"
+          submodules: true
+
+      - name: Use HTTPS instead of SSH for Git cloning
+        run: git config --global url.https://github.com/.insteadOf ssh://git@github.com/
+
+      - name: Run OSS Review Toolkit
+        id: ort
+        uses: oss-review-toolkit/ort-ci-github-action@1805edcf1f4f55f35ae6e4d2d9795ccfb29b6021 # v1.1.0
+        with:
+          image: ghcr.io/oss-review-toolkit/ort:80.0.0
+          run: >-
+            labels,
+            cache-dependencies,
+            cache-scan-results,
+            analyzer,
+            scanner,
+            advisor,
+            reporter
+          report-formats: "CycloneDx,SpdxDocument,WebApp"
+          # TODO: Remove workaround once https://github.com/oss-review-toolkit/ort/pull/11324 is merged
+          ort-cli-args: >-
+            -P ort.analyzer.skipExcluded=true
+            -P ort.scanner.scanners.ScanCode.options.commandLine=--copyright,--license,--info,--strip-root
+            -P ort.scanner.scanners.ScanCode.options.commandLineNonConfig=--timeout,300
+          ort-cli-report-args: >-
+            -O CycloneDX=output.file.formats=json,xml
+            -O SpdxDocument=outputFileFormats=JSON,YAML
+          sw-version: "${{ github.ref_type == 'tag' && github.ref_name || github.sha }}"
+
+      - name: "Rename SBOMs"
+        run: |
+          cp "$CYCLONEDX_XML" sbom.cdx.xml
+          cp "$CYCLONEDX_JSON" sbom.cdx.json
+          cp "$SPDX_YML" sbom.spdx.yml
+          cp "$SPDX_JSON" sbom.spdx.json
+        env:
+          CYCLONEDX_XML: "${{ steps.ort.outputs.results-sbom-cyclonedx-xml-path }}"
+          CYCLONEDX_JSON: "${{ steps.ort.outputs.results-sbom-cyclonedx-json-path }}"
+          SPDX_YML: "${{ steps.ort.outputs.results-sbom-spdx-yml-path }}"
+          SPDX_JSON: "${{ steps.ort.outputs.results-sbom-spdx-json-path }}"
 
       - name: "Attest provenance"
         uses: actions/attest-build-provenance@96278af6caaf10aea03fd8d33a09a777ca52d62f # v3.2.0
         id: attest-provenance
         if: "${{ inputs.attest }}"
         with:
-          subject-path: 'source_sbom.spdx'
+          subject-path: |
+            sbom.cdx.xml
+            sbom.cdx.json
+            sbom.spdx.yml
+            sbom.spdx.json
+
       - name: "Copy provenance"
         if: "${{ inputs.attest }}"
-        run: cp "$ATTESTATION" source_sbom.spdx.sigstore
+        run: |
+          cp "$ATTESTATION" sbom.cdx.xml.sigstore
+          cp "$ATTESTATION" sbom.cdx.json.sigstore
+          cp "$ATTESTATION" sbom.spdx.yml.sigstore
+          cp "$ATTESTATION" sbom.spdx.json.sigstore
         env:
           ATTESTATION: "${{ steps.attest-provenance.outputs.bundle-path }}"
-      
+
       - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
-          name: source_sbom
+          name: sbom
           path: |
-            source_sbom.spdx
-            source_sbom.spdx.sigstore
+            sbom.cdx.xml
+            sbom.cdx.json
+            sbom.spdx.yml
+            sbom.spdx.json
+            sbom.*.sigstore
+
+      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: sbom_report
+          path: ${{ steps.ort.outputs.results-path }}/scan-report-web-app.html
 
   check:
-    name: "Check Licensing Compliance"
+    name: "Check REUSE Licensing Compliance"
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/part_release.yml
+++ b/.github/workflows/part_release.yml
@@ -31,7 +31,7 @@ jobs:
         uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
         with:
           egress-policy: audit
-            
+
       - name: "Download Docs Artifact"
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
@@ -45,7 +45,7 @@ jobs:
       - name: "Download Source SBoM Artifact"
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
-          name: source_sbom
+          name: sbom
           path: .
 
       - name: Create release
@@ -60,4 +60,4 @@ jobs:
           --generate-notes
           ${{ !inputs.stable && '--prerelease' || '' }}
           "$RELEASE_NAME"
-          docs.tar.gz* mix_sbom* source_sbom*
+          docs.tar.gz* mix_sbom_* sbom.*

--- a/.github/workflows/tag-stable.yml
+++ b/.github/workflows/tag-stable.yml
@@ -42,10 +42,22 @@ jobs:
 
     uses: ./.github/workflows/part_docs.yml
 
+  attest_sbom:
+    name: "Attest SBOM"
+
+    needs: ["build", "licensing", "docs"]
+
+    permissions:
+      id-token: write
+      contents: read
+      attestations: write
+
+    uses: ./.github/workflows/part_attest_sbom.yml
+
   release:
     name: Create Release
 
-    needs: ["build", "licensing", "docs"]
+    needs: ["build", "licensing", "docs", "attest_sbom"]
 
     permissions:
       contents: write

--- a/.github/workflows/tag-unstable.yml
+++ b/.github/workflows/tag-unstable.yml
@@ -42,10 +42,22 @@ jobs:
 
     uses: ./.github/workflows/part_docs.yml
 
+  attest_sbom:
+    name: "Attest SBOM"
+
+    needs: ["build", "licensing", "docs"]
+
+    permissions:
+      id-token: write
+      contents: read
+      attestations: write
+
+    uses: ./.github/workflows/part_attest_sbom.yml
+
   release:
     name: Create Release
 
-    needs: ["build", "licensing", "docs"]
+    needs: ["build", "licensing", "docs", "attest_sbom"]
 
     permissions:
       contents: write

--- a/.ort.yml
+++ b/.ort.yml
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# SPDX-FileCopyrightText: 2026 Erlang Ecosystem Foundation
+
+excludes:
+  scopes:
+    - pattern: "excluded"
+      reason: "DEV_DEPENDENCY_OF"
+      comment: "Development dependencies not included in production builds"
+  paths:
+    # CI/CD and build configuration
+    - pattern: ".github/**"
+      reason: "BUILD_TOOL_OF"
+      comment: "GitHub Actions workflows and configuration"
+    - pattern: "devenv.*"
+      reason: "BUILD_TOOL_OF"
+      comment: "Devenv configuration"
+    - pattern: ".envrc"
+      reason: "BUILD_TOOL_OF"
+      comment: "Direnv configuration"
+    - pattern: ".tool-versions"
+      reason: "BUILD_TOOL_OF"
+      comment: "asdf version manager configuration"
+
+    # Documentation
+    - pattern: "README.md"
+      reason: "DOCUMENTATION_OF"
+      comment: "Project readme"
+
+    # Tests
+    - pattern: "test/**"
+      reason: "TEST_OF"
+      comment: "Test files"
+    - pattern: "coveralls.json*"
+      reason: "TEST_TOOL_OF"
+      comment: "Coverage configuration"
+    - pattern: "config/**"
+      reason: "BUILD_TOOL_OF"
+      comment: "Test Application configuration"
+
+    # Static analysis configuration
+    - pattern: ".credo.exs"
+      reason: "BUILD_TOOL_OF"
+      comment: "Credo linter configuration"
+    - pattern: ".dialyzer_ignore.exs"
+      reason: "BUILD_TOOL_OF"
+      comment: "Dialyzer ignore configuration"
+    - pattern: ".formatter.exs"
+      reason: "BUILD_TOOL_OF"
+      comment: "Elixir formatter configuration"
+
+    # License metadata files
+    - pattern: "REUSE.toml"
+      reason: "DOCUMENTATION_OF"
+      comment: "REUSE configuration"


### PR DESCRIPTION
Replaces REUSE with ORT to generate SBoM files for releases.

Needs https://github.com/erlef/bombom/issues/8 to be fixed and https://github.com/oss-review-toolkit/ort/pull/11319 merged / released.

Implements https://github.com/stritzinger/sosef/issues/78