### PR TITLE
Add component.group field to CycloneDX SBOMs

### DIFF
--- a/lib/sbom/cyclonedx.ex
+++ b/lib/sbom/cyclonedx.ex
@@ -305,6 +305,7 @@ defmodule SBoM.CycloneDX do
     bom_struct(:Component, schema_version,
       type: :CLASSIFICATION_LIBRARY,
       name: name,
+      group: component[:group],
       version: component_version(component, schema_version),
       purl: to_string(component.package_url),
       scope: dependency_scope(component),

--- a/lib/sbom/scm.ex
+++ b/lib/sbom/scm.ex
@@ -66,6 +66,17 @@ defmodule SBoM.SCM do
   @callback enhance_metadata(app :: atom(), dependency :: map()) :: map()
 
   @doc """
+  Returns the group identifier for the given dependency.
+
+  Used to categorize components in the SBOM by their origin. For example:
+  - Erlang OTP applications → `"erlang.otp"`
+  - Elixir stdlib applications → `"elixir.stdlib"`
+
+  Returns `nil` if no group applies.
+  """
+  @callback group(app :: atom(), dependency :: map()) :: String.t() | nil
+
+  @doc """
   Returns a list of app names representing sub-dependencies found in the lock.
 
   Only used if the SCM implementation supports this and provides custom logic.

--- a/lib/sbom/scm/hex/scm.ex
+++ b/lib/sbom/scm/hex/scm.ex
@@ -277,6 +277,12 @@ defmodule SBoM.SCM.Hex.SCM do
     )
   end
 
+  @impl SCM
+  def group(_app, %{mix_lock: [:hex, _name, _version, _checksum, _managers, _deps, repo | _rest]}), do: repo
+
+  def group(_app, %{mix_dep: {_name, _requirement, opts}}), do: opts[:repo]
+  def group(_app, _dependency), do: nil
+
   @spec hex_namespace(repo :: String.t() | nil) :: Purl.namespace()
   defp hex_namespace(repo)
   defp hex_namespace(nil), do: []

--- a/lib/sbom/scm/mix/scm/git.ex
+++ b/lib/sbom/scm/mix/scm/git.ex
@@ -115,4 +115,23 @@ defmodule SBoM.SCM.Mix.SCM.Git do
     [:git, _repo_url, revision | _rest] = lock
     revision
   end
+
+  @impl SCM
+  def group(app, %{mix_lock: mix_lock}) do
+    app
+    |> mix_lock_to_purl(mix_lock)
+    |> purl_namespace()
+  end
+
+  def group(_app, %{mix_dep: mix_dep} = dependency) do
+    mix_dep
+    |> mix_dep_to_purl(dependency[:version])
+    |> purl_namespace()
+  end
+
+  def group(_app, _dependency), do: nil
+
+  @spec purl_namespace(Purl.t()) :: String.t() | nil
+  defp purl_namespace(%Purl{namespace: []}), do: nil
+  defp purl_namespace(%Purl{namespace: namespace}), do: Enum.join(namespace, "/")
 end

--- a/lib/sbom/scm/mix/scm/path.ex
+++ b/lib/sbom/scm/mix/scm/path.ex
@@ -49,4 +49,7 @@ defmodule SBoM.SCM.Mix.SCM.Path do
       version: requirement || version
     })
   end
+
+  @impl SCM
+  def group(_app, _dependency), do: nil
 end

--- a/lib/sbom/scm/system.ex
+++ b/lib/sbom/scm/system.ex
@@ -197,4 +197,10 @@ defmodule SBoM.SCM.SBoM.SCM.System do
   end
 
   def enhance_metadata(_app, _dependency), do: %{}
+
+  @impl SBoM.SCM
+  def group(app, _dependency) when is_elixir_app(app), do: "elixir.stdlib"
+  def group(app, _dependency) when is_erlang_app(app), do: "erlang.otp"
+  def group(app, _dependency) when is_hex_app(app), do: "hex"
+  def group(_app, _dependency), do: nil
 end

--- a/test/sbom/cyclonedx_test.exs
+++ b/test/sbom/cyclonedx_test.exs
@@ -236,4 +236,15 @@ defmodule SBoM.CycloneDXTest do
       end)
     end
   end
+
+  describe "component group" do
+    test "group field is populated in components" do
+      components = Fetcher.fetch()
+      bom = CycloneDX.bom_for_components(components)
+
+      # Verify group is set for system components
+      stdlib_component = Enum.find(bom.components, &(&1.name == "stdlib"))
+      assert stdlib_component.group == "erlang.otp"
+    end
+  end
 end

--- a/test/sbom/scm/hex/scm_test.exs
+++ b/test/sbom/scm/hex/scm_test.exs
@@ -104,4 +104,42 @@ defmodule SBoM.SCM.Hex.SCMTest do
         assert.(response)
     end
   end
+
+  describe "group/2" do
+    test "returns repo from mix_lock" do
+      dependency = %{
+        mix_lock: [:hex, :jason, "1.4.0", "checksum", [:mix], [], "hexpm", "checksum"]
+      }
+
+      assert SCM.group(:jason, dependency) == "hexpm"
+    end
+
+    test "returns repo with org from mix_lock" do
+      dependency = %{
+        mix_lock: [:hex, :private_pkg, "1.0.0", "checksum", [:mix], [], "hexpm:myorg", "checksum"]
+      }
+
+      assert SCM.group(:private_pkg, dependency) == "hexpm:myorg"
+    end
+
+    test "returns repo from mix_dep when no mix_lock" do
+      dependency = %{
+        mix_dep: {:jason, "~> 1.0", [hex: :jason, repo: "hexpm"]}
+      }
+
+      assert SCM.group(:jason, dependency) == "hexpm"
+    end
+
+    test "returns repo with org from mix_dep" do
+      dependency = %{
+        mix_dep: {:private_pkg, "~> 1.0", [hex: :private_pkg, repo: "hexpm:myorg"]}
+      }
+
+      assert SCM.group(:private_pkg, dependency) == "hexpm:myorg"
+    end
+
+    test "returns nil when no hex info available" do
+      assert SCM.group(:app, %{}) == nil
+    end
+  end
 end

--- a/test/sbom/scm/mix/scm/git_test.exs
+++ b/test/sbom/scm/mix/scm/git_test.exs
@@ -7,4 +7,30 @@ defmodule SBoM.SCM.Mix.SCM.GitTest do
   alias SBoM.SCM.Mix.SCM.Git
 
   doctest Git
+
+  describe "group/2" do
+    test "extracts org from GitHub HTTPS URL via mix_lock" do
+      dependency = %{mix_lock: [:git, "https://github.com/elixir-lang/elixir.git", "abc123"]}
+      assert Git.group(:elixir, dependency) == "elixir-lang"
+    end
+
+    test "extracts org from GitHub SSH URL via mix_lock" do
+      dependency = %{mix_lock: [:git, "git@github.com:erlang/otp.git", "abc123"]}
+      assert Git.group(:otp, dependency) == "erlang"
+    end
+
+    test "extracts org from GitHub URL via mix_dep" do
+      dependency = %{mix_dep: {:myapp, nil, [git: "https://github.com/someuser/myapp.git"]}}
+      assert Git.group(:myapp, dependency) == "someuser"
+    end
+
+    test "returns nil for non-GitHub hosts" do
+      dependency = %{mix_lock: [:git, "https://git.example.com/myorg/repo.git", "abc123"]}
+      assert Git.group(:repo, dependency) == nil
+    end
+
+    test "returns nil when no git info available" do
+      assert Git.group(:app, %{}) == nil
+    end
+  end
 end

--- a/test/sbom/scm/system_test.exs
+++ b/test/sbom/scm/system_test.exs
@@ -61,6 +61,30 @@ defmodule SBoM.SCM.SystemTest do
     end
   end
 
+  describe "group/2" do
+    test "returns elixir.stdlib for elixir apps" do
+      for app <- [:elixir, :mix, :logger, :eex, :ex_unit, :iex] do
+        assert SystemSCM.group(app, %{}) == "elixir.stdlib",
+               "Expected #{app} to have group elixir.stdlib"
+      end
+    end
+
+    test "returns erlang.otp for erlang apps" do
+      for app <- [:kernel, :stdlib, :crypto, :ssl] do
+        assert SystemSCM.group(app, %{}) == "erlang.otp",
+               "Expected #{app} to have group erlang.otp"
+      end
+    end
+
+    test "returns hex for hex app" do
+      assert SystemSCM.group(:hex, %{}) == "hex"
+    end
+
+    test "returns nil for unknown apps" do
+      assert SystemSCM.group(:unknown_app, %{}) == nil
+    end
+  end
+
   describe "mix_dep_to_purl/2" do
     test "includes download_url and vcs_url in qualifiers for elixir apps" do
       purl = SystemSCM.mix_dep_to_purl({:elixir, nil, []}, "1.15.0")


### PR DESCRIPTION
Implements #64: Components are now categorized by their origin using the CycloneDX group field:

- Erlang OTP apps → "erlang.otp"
- Elixir stdlib apps → "elixir.stdlib"
- Hex app → "hex"
- Hex packages → repo name (e.g., "hexpm", "hexpm:myorg")
- Git packages → org or user from git URL (where supported)
- Path dependencies → nil