### PR TITLE
Add --hex-api-key / HEX_API_KEY

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,9 @@ output; the task should normally be run in the default (dev) environment*
 - `-r, --recurse`: Recurse into umbrella applications
 - `-x, --exclude-system-dependencies`: Exclude system dependencies (Erlang/OTP,
   Elixir, Hex) from the SBoM
+- `--hex-api-key KEY`: Hex.pm API key used to authenticate metadata requests,
+  avoiding rate limits. Falls back to the `HEX_API_KEY` environment variable
+  if not provided. Omitted entirely when neither is set.
 
 For more information:
 

--- a/lib/sbom/cli.ex
+++ b/lib/sbom/cli.ex
@@ -44,6 +44,8 @@ defmodule SBoM.CLI do
 
   @spec generate_bom_content(Optimus.ParseResult.t()) :: :ok
   defp generate_bom_content(parse_result) do
+    set_hex_api_key(parse_result.options[:hex_api_key])
+
     case parse_result.args[:project_path] do
       nil ->
         generate_bom_content_in_project(parse_result)
@@ -52,6 +54,15 @@ defmodule SBoM.CLI do
         SBoM.Util.in_project(path, fn _mix_project ->
           generate_bom_content_in_project(parse_result)
         end)
+    end
+  end
+
+  @spec set_hex_api_key(String.t() | nil) :: :ok
+  defp set_hex_api_key(cli_key) do
+    case cli_key || System.get_env("HEX_API_KEY") do
+      nil -> Application.delete_env(:sbom, :hex_api_key)
+      "" -> Application.delete_env(:sbom, :hex_api_key)
+      key -> Application.put_env(:sbom, :hex_api_key, key)
     end
   end
 
@@ -222,6 +233,15 @@ defmodule SBoM.CLI do
               required: false,
               default: @default_classification,
               parser: &parse_classification/1
+            ],
+            hex_api_key: [
+              value_name: "HEX_API_KEY",
+              long: "--hex-api-key",
+              help:
+                "Hex.pm API key used to authenticate metadata requests, avoiding rate limits. " <>
+                  "Falls back to the HEX_API_KEY environment variable if not provided.",
+              required: false,
+              parser: :string
             ]
           ],
           flags: [

--- a/lib/sbom/scm/hex/scm.ex
+++ b/lib/sbom/scm/hex/scm.ex
@@ -258,12 +258,14 @@ defmodule SBoM.SCM.Hex.SCM do
   defp fetch_hex_metadata(app, version) do
     package_payload =
       :hex_core.default_config()
+      |> maybe_put_api_key()
       |> :hex_api_package.get(Atom.to_string(app))
       |> hex_response()
 
     release_payload =
       if version do
         :hex_core.default_config()
+        |> maybe_put_api_key()
         |> :hex_api_release.get(Atom.to_string(app), version)
         |> hex_response()
       else
@@ -275,6 +277,15 @@ defmodule SBoM.SCM.Hex.SCM do
       Metadata.from_hex_payload(package_payload),
       Metadata.from_hex_payload(release_payload)
     )
+  end
+
+  @spec maybe_put_api_key(map()) :: map()
+  defp maybe_put_api_key(config) do
+    case Application.get_env(:sbom, :hex_api_key) do
+      nil -> config
+      "" -> config
+      key when is_binary(key) -> Map.put(config, :api_key, key)
+    end
   end
 
   @impl SCM


### PR DESCRIPTION
On large projects I sometimes get "Hex API rate limit exceeded". This adds a CLI option and env var to specify a Hex API key to increase the rate limit.