### PR TITLE
Inherit parent scope for transitive dependencies

### DIFF
--- a/lib/sbom/fetcher.ex
+++ b/lib/sbom/fetcher.ex
@@ -204,31 +204,19 @@ defmodule SBoM.Fetcher do
 
   @spec only_contributions(%{app_name() => dependency()}, only_index()) :: [only_contribution()]
   defp only_contributions(deps, effective) do
-    Enum.flat_map(deps, fn {app, dep} ->
-      case Map.get(effective, app) do
-        nil ->
-          []
+    for {app, dep} <- deps,
+        parent_only = Map.get(effective, app),
+        not is_nil(parent_only),
+        children = Map.get(dep, :dependencies, []),
+        child <- List.wrap(children),
+        {:ok, child_dep} <- [Map.fetch(deps, child)] do
+      declared =
+        dep
+        |> declared_only(child_dep)
+        |> restrict_only(parent_only)
 
-        parent_only ->
-          dep
-          |> Map.get(:dependencies, [])
-          |> List.wrap()
-          |> Enum.flat_map(fn child ->
-            case Map.fetch(deps, child) do
-              {:ok, child_dep} ->
-                declared =
-                  dep
-                  |> declared_only(child_dep)
-                  |> restrict_only(parent_only)
-
-                [{child, declared}]
-
-              :error ->
-                []
-            end
-          end)
-      end
-    end)
+      {child, declared}
+    end
   end
 
   @spec declared_only(dependency(), dependency()) :: only_scope()
@@ -429,6 +417,5 @@ defmodule SBoM.Fetcher do
   @doc false
   @spec drop_empty(map :: %{key => value | nil}) :: %{key => value}
         when key: term(), value: term()
-  def drop_empty(map),
-    do: map |> Enum.reject(fn {_key, value} -> value in [nil, ""] end) |> Map.new()
+  def drop_empty(map), do: map |> Enum.reject(fn {_key, value} -> value in [nil, ""] end) |> Map.new()
 end

--- a/lib/sbom/fetcher.ex
+++ b/lib/sbom/fetcher.ex
@@ -49,6 +49,10 @@ defmodule SBoM.Fetcher do
   """
   @type fetch_opts() :: [system_dependencies: boolean()]
 
+  @typep only_scope() :: :* | [atom()]
+  @typep only_index() :: %{app_name() => nil | only_scope()}
+  @typep only_contribution() :: {app_name(), only_scope()}
+
   @doc """
   Fetches dependencies from a specific source.
 
@@ -154,9 +158,93 @@ defmodule SBoM.Fetcher do
             filter_system_dependencies(deps)
           end
 
-        transform_all(deps)
+        deps
+        |> propagate_only()
+        |> transform_all()
     end
   end
+
+  @doc false
+  @spec propagate_only(%{app_name() => dependency()}) :: %{app_name() => dependency()}
+  def propagate_only(deps) do
+    seed =
+      Map.new(deps, fn
+        {app, %{root: true}} -> {app, :*}
+        {app, _dep} -> {app, nil}
+      end)
+
+    effective = resolve_only(deps, seed)
+
+    Map.new(deps, fn {app, dep} ->
+      case Map.get(effective, app) do
+        nil -> {app, dep}
+        only -> {app, Map.put(dep, :only, only)}
+      end
+    end)
+  end
+
+  @spec resolve_only(%{app_name() => dependency()}, only_index()) :: only_index()
+  defp resolve_only(deps, effective) do
+    reducer =
+      fn {child, contribution}, acc ->
+        Map.update(acc, child, contribution, &union_only(&1, contribution))
+      end
+
+    next =
+      deps
+      |> only_contributions(effective)
+      |> Enum.reduce(effective, reducer)
+
+    if next == effective do
+      effective
+    else
+      resolve_only(deps, next)
+    end
+  end
+
+  @spec only_contributions(%{app_name() => dependency()}, only_index()) :: [only_contribution()]
+  defp only_contributions(deps, effective) do
+    Enum.flat_map(deps, fn {app, dep} ->
+      case Map.get(effective, app) do
+        nil ->
+          []
+
+        parent_only ->
+          dep
+          |> Map.get(:dependencies, [])
+          |> List.wrap()
+          |> Enum.flat_map(fn child ->
+            case Map.fetch(deps, child) do
+              {:ok, child_dep} ->
+                declared =
+                  dep
+                  |> declared_only(child_dep)
+                  |> restrict_only(parent_only)
+
+                [{child, declared}]
+
+              :error ->
+                []
+            end
+          end)
+      end
+    end)
+  end
+
+  @spec declared_only(dependency(), dependency()) :: only_scope()
+  defp declared_only(%{root: true}, child_dep), do: Map.get(child_dep, :only, :*)
+  defp declared_only(_parent_dep, _child_dep), do: :*
+
+  @spec restrict_only(only_scope(), only_scope()) :: only_scope()
+  defp restrict_only(declared, :*), do: declared
+  defp restrict_only(:*, parent), do: parent
+  defp restrict_only(declared, parent), do: parent -- (parent -- declared)
+
+  @spec union_only(nil | only_scope(), only_scope()) :: only_scope()
+  defp union_only(nil, right), do: right
+  defp union_only(:*, _right), do: :*
+  defp union_only(_left, :*), do: :*
+  defp union_only(left, right), do: Enum.uniq(left ++ right)
 
   @spec filter_system_dependencies(%{app_name() => dependency()}) :: %{app_name() => dependency()}
   defp filter_system_dependencies(deps) do
@@ -341,5 +429,6 @@ defmodule SBoM.Fetcher do
   @doc false
   @spec drop_empty(map :: %{key => value | nil}) :: %{key => value}
         when key: term(), value: term()
-  def drop_empty(map), do: map |> Enum.reject(fn {_key, value} -> value in [nil, ""] end) |> Map.new()
+  def drop_empty(map),
+    do: map |> Enum.reject(fn {_key, value} -> value in [nil, ""] end) |> Map.new()
 end

--- a/test/sbom/fetcher_test.exs
+++ b/test/sbom/fetcher_test.exs
@@ -80,6 +80,43 @@ defmodule SBoM.FetcherTest do
     end
   end
 
+  describe inspect(&Fetcher.propagate_only/1) do
+    test "inherits dev-only parent's scope for transitive dependencies" do
+      deps =
+        Fetcher.propagate_only(%{
+          root: %{root: true, only: :*, dependencies: [:credo]},
+          credo: %{only: [:dev], dependencies: [:bunt]},
+          bunt: %{only: :*, dependencies: []}
+        })
+
+      assert %{only: [:dev]} = deps.credo
+      assert %{only: [:dev]} = deps.bunt
+    end
+
+    test "unions scopes for shared dependencies" do
+      deps =
+        Fetcher.propagate_only(%{
+          root: %{root: true, only: :*, dependencies: [:credo, :jason]},
+          credo: %{only: [:dev], dependencies: [:shared]},
+          jason: %{only: :*, dependencies: [:shared]},
+          shared: %{only: :*, dependencies: []}
+        })
+
+      assert %{only: :*} = deps.shared
+    end
+
+    test "a dev only dep pulled by a prod dep resolves to prod" do
+      deps =
+        Fetcher.propagate_only(%{
+          root: %{root: true, only: :*, dependencies: [:jason, :oban]},
+          jason: %{only: [:dev], dependencies: []},
+          oban: %{only: :*, dependencies: [:jason]}
+        })
+
+      assert %{only: :*} = deps.jason
+    end
+  end
+
   @tag :tmp_dir
   @tag fixture_app: "umbrella"
   test "does umbrella correctly", %{app_path: app_path, app_name: app_name} do


### PR DESCRIPTION
Previously, the `--only` option would still include the transitive dependencies of ignored packages. The internal `only` scope would default to `:*` rather than inheriting the parent's scope. In practice that made it impossible to generate clean `--only prod` output, because the transitive deps from all `dev` and `test` were always included.

Now dependency fetching passes through an internal `propagate_only/1` function that recursively applies scoping for all dependencies.